### PR TITLE
既にGoogleでログインしたことある場合にはデータ登録をしないように変更

### DIFF
--- a/app/app/Models/UserAuthentication.php
+++ b/app/app/Models/UserAuthentication.php
@@ -12,7 +12,7 @@ class UserAuthentication extends Model
     const PROVIDER_GOOGLE = 'google';
 
     protected $fillable = [
-        'identify',
+        'identifier',
         'provider',
         'user_id'
     ];


### PR DESCRIPTION
## 概要
#34 でテーブルをユーザー情報と認証情報で分離したけど、google callbackでの処理に考慮漏れがありました。
一度ログインしたことがあって再ログインする場合でも `user_authentications`テーブルに書いてたのでログインするたびにデータが増えていたので、既に登録されているかを考慮するようにしています