### PR TITLE
Trival improve: Increase recent turn log

### DIFF
--- a/app/app/Http/Controllers/Islands/DetailController.php
+++ b/app/app/Http/Controllers/Islands/DetailController.php
@@ -10,7 +10,8 @@ use App\Services\Hakoniwa\Terrain\Terrain;
 
 class DetailController extends Controller
 {
-    const DEFAULT_SHOW_LOG_TURNS = 5;
+    // TODO Consider to reduce count of recent turns log after making log detail page.
+    const DEFAULT_SHOW_LOG_TURNS = 20;
     public function get($islandId) {
         $island = Island::find($islandId);
 

--- a/app/app/Http/Controllers/Islands/PlansController.php
+++ b/app/app/Http/Controllers/Islands/PlansController.php
@@ -32,8 +32,7 @@ class PlansController extends Controller
         }
 
         $turn = Turn::latest()->firstOrFail();
-        // TODO 直近取得ターンの変数切り出し
-        $getLogRecentTurns = 5;
+        $getLogRecentTurns = DEFAULT_SHOW_LOG_TURNS;
 
 //        $islandTerrain = Terrains::find($islandId);
 //        $islandTerrain->terrain = Terrains::create()->init()->toJson();

--- a/app/app/Http/Controllers/Islands/PlansController.php
+++ b/app/app/Http/Controllers/Islands/PlansController.php
@@ -17,7 +17,8 @@ class PlansController extends Controller
 {
     use WebApi;
 
-    const DEFAULT_SHOW_LOG_TURNS = 5;
+    // TODO Consider to reduce count of recent turns log after making log detail page.
+    const DEFAULT_SHOW_LOG_TURNS = 20;
 
     public function get(int $islandId)
     {


### PR DESCRIPTION
## Overview
Increase recent turn log on plan screen and detail screen.

## Description
Currently, we show the recent turn log on the bottom of the plan screen and detail screen.
But we only recognize the 5 turn log. In short, we cannot recognize what does it happened other turns.
So increase the number of recent turn log to show more logs.

And it includes small fix to use const value as a recent turn count instead.

## Out of scope
We just increase recent turn log. We should make the new screen to show the entire logs.
But in this PR, we don't make it.