### PR TITLE
各種CSSアニメーションの追加

### DIFF
--- a/app/resources/js/components/IslandEditor.vue
+++ b/app/resources/js/components/IslandEditor.vue
@@ -283,6 +283,7 @@ export default {
 
     .hover-window {
         @apply block absolute min-w-[200px] max-w-[200px] bg-black bg-opacity-50 p-1 text-white rounded-md border border-black -translate-x-1/2 z-30;
+
         .hover-window-header {
             @apply flex px-3 items-center;
 
@@ -308,6 +309,7 @@ export default {
 
     .plan-window {
         @apply block absolute bg-gray-300 w-fit lg:max-w-[240px] rounded-md drop-shadow-md text-left overflow-hidden max-md:text-sm border border-gray-800 z-30;
+        @apply animate-fadein;
 
         .plan-window-header {
             @apply flex p-0 m-0 bg-gray-700 text-white items-center;

--- a/app/resources/js/components/RankingViewer.vue
+++ b/app/resources/js/components/RankingViewer.vue
@@ -89,7 +89,6 @@ export default {
 
     methods: {
         onAppeared() {
-            console.log("appeared!")
             this.isAppeared = true;
             this.observer.disconnect();
         }

--- a/app/resources/js/components/RankingViewer.vue
+++ b/app/resources/js/components/RankingViewer.vue
@@ -1,5 +1,10 @@
 <template>
-    <a :href="'/islands/' + $props.island.id">
+    <a
+        :href="'/islands/' + $props.island.id"
+        :id="'ranking-' + $props.island.id"
+        class="block"
+        :class="[isAppeared ? 'animate-slide-in-left' : '']"
+    >
         <div class="ranking">
             <div class="ranking-index">
                 <div class="ranking-index-num">{{ $props.index }}</div>
@@ -59,6 +64,36 @@
 
 <script>
 export default {
+    data() {
+        return {
+            observer : IntersectionObserver,
+            isAppeared: false // スクリーン上に出てきたかどうか
+        }
+    },
+    mounted() {
+        const target = document.querySelector("#ranking-" + this.island.id);
+
+        const options = {
+            root: null,
+            rootMargin: "0px",
+            threshold: 1
+        }
+
+        this.observer = new IntersectionObserver(entries => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) this.onAppeared();
+            })
+        });
+        this.observer.observe(target, options);
+    },
+
+    methods: {
+        onAppeared() {
+            console.log("appeared!")
+            this.isAppeared = true;
+            this.observer.disconnect();
+        }
+    },
     props: ['index', 'island']
 }
 </script>
@@ -100,6 +135,6 @@ export default {
             }
         }
     }
-
 }
+
 </style>

--- a/app/resources/js/components/VueHeader.vue
+++ b/app/resources/js/components/VueHeader.vue
@@ -12,7 +12,8 @@
             <img src="/img/hakoniwa/ui/hamburger.svg">
         </button>
 
-        <div class="md:ml-auto max-md:w-full" :class="{'max-md:hidden': !isOpenHamburgerMenu}">
+        <div class="hamburger-elements"
+             :class="[isOpenHamburgerMenu ? 'max-md:max-h-36' : 'max-md:max-h-0']">
             <div v-if="isLoggedIn" class="navbar-menu">
                 <div class="navbar-item navbar-username">
                     {{ user.name }}
@@ -97,6 +98,10 @@ export default {
 
     #hamburger-button {
         @apply ml-auto mr-3 block w-7 h-7 md:hidden;
+    }
+
+    .hamburger-elements {
+        @apply md:ml-auto max-md:w-full transition-all duration-500 ease-in-out overflow-hidden;
     }
 
     .navbar-menu {

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -38,6 +38,21 @@ module.exports = {
                     dark: "#a62640"
                 }
             },
+            animation: {
+                "slide-in-left": "slide-in-left 1.2s"
+            },
+            keyframes: {
+                "slide-in-left": {
+                    "0%": {
+                        transform: "translateX(-20%)",
+                        opacity: 0,
+                    },
+                    "100%": {
+                        transform: "translateX(0%)",
+                        opacity: 1
+                    }
+                }
+            }
         },
     },
     plugins: [],

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -8,7 +8,7 @@ module.exports = {
     theme: {
         extend: {
             screens: {
-              xs: '350px'
+                xs: '350px'
             },
             colors: {
                 primary: {
@@ -39,9 +39,18 @@ module.exports = {
                 }
             },
             animation: {
+                "fadein": "fadein 0.3s",
                 "slide-in-left": "slide-in-left 1.2s"
             },
             keyframes: {
+                "fadein": {
+                    "0%": {opacity: 0},
+                    "100%": {opacity: 1}
+                },
+                "fadeout": {
+                    "0%": {opacity: 1},
+                    "100%": {opacity: 0}
+                },
                 "slide-in-left": {
                     "0%": {
                         transform: "translateX(-20%)",


### PR DESCRIPTION
# Overview

#46 への対応です。
うるさくならない範囲で、各種CSSアニメーションを追加しました。

# Description

## Hamburger Menu

スライドして上下するようにしました。
本実装がデスクトップビュー時に悪さをしないことも確認済みです。
![hamburger](https://user-images.githubusercontent.com/130939038/236655212-d962edec-8384-437a-a27e-ffa670f3fb8c.gif)

## Index / Ranking

スクロールして画面上に表示されると、左から徐々にフェードインしてくるアニメーションを実装しました。
![ranking](https://user-images.githubusercontent.com/130939038/236655257-e27f253d-258d-4440-832b-517ce2cb64bc.gif)

## Editor / PlanMenu

マスを選択した際に表示されるメニューを、表示時にフェードインするようにしました。
![planmenu](https://user-images.githubusercontent.com/130939038/236655295-a77a35ef-f0ba-44a5-8c07-37a480f5dd04.gif)

## Others

ホバーした時のメニューについてもアニメーションを一度は実装したのですが、視認性が悪くなったのでやめました。