### PR TITLE
スマホビューでPlanListが意図しない動作をする問題の解決

### DIFF
--- a/app/resources/js/components/IslandEditor.vue
+++ b/app/resources/js/components/IslandEditor.vue
@@ -55,7 +55,7 @@
                     </template>
 
         </div>
-        <div v-show="showPlanWindow" class="plan-window"
+        <div v-show="showPlanWindow" class="plan-window" ref="planWindow"
              :style="[
                  { top: planWindowY + 'px' },
                  !isMobile || planWindowLeftSide ? { left: planWindowX + 'px' } : { right: planWindowX + 'px' }
@@ -132,10 +132,10 @@ export default {
 
             // Screen Overflow Check
             if(this.isMobile) {
-                const windowSize = 200;
+                const elementWidth = 200;
                 const paddingOffset = 20;
-                const leftEdge = this.hoverWindowX - (windowSize/2);
-                const rightEdge = this.hoverWindowX + (windowSize/2);
+                const leftEdge = this.hoverWindowX - (elementWidth/2);
+                const rightEdge = this.hoverWindowX + (elementWidth/2);
                 if (leftEdge < paddingOffset) {
                     this.hoverWindowX += (-leftEdge) + paddingOffset;
                 }
@@ -163,15 +163,25 @@ export default {
             this.$store.state.selectedPoint.y = y;
             this.showPlanWindow = true;
 
-            this.planWindowLeftSide = (x < 7);
-
-            const offset = 15;
-            this.planWindowY = event.pageY + offset;
             if(this.isMobile) {
-                this.planWindowX = this.planWindowLeftSide ? event.pageX + offset : (document.documentElement.clientWidth - event.pageX - offset);
+                this.planWindowX = event.pageX;
+                const offsetX = 15;
+                const offsetY = 30;
+                const elementWidth = 230;
+                const leftEdge = this.planWindowX - (elementWidth/2);
+                const rightEdge = this.planWindowX + (elementWidth/2);
+                if (leftEdge < offsetX) {
+                    this.planWindowX += (-leftEdge) + offsetX;
+                }
+                else if (rightEdge > this.screenWidth) {
+                    this.planWindowX -= (rightEdge-this.screenWidth) + offsetX;
+                }
+                this.planWindowY = event.pageY + offsetY;
             }
             else {
+                const offset = 15;
                 this.planWindowX = event.pageX + offset;
+                this.planWindowY = event.pageY + offset;
             }
         },
         onClickPlan(key) {
@@ -312,7 +322,7 @@ export default {
     }
 
     .plan-window {
-        @apply block absolute bg-gray-300 w-fit lg:max-w-[240px] rounded-md drop-shadow-md text-left overflow-hidden max-md:text-sm border border-gray-800 z-30;
+        @apply block absolute bg-gray-300 w-fit max-lg:min-w-[230px] max-lg:max-w-[230px] max-lg:-translate-x-1/2 lg:max-w-[240px] rounded-md drop-shadow-md text-left overflow-hidden max-md:text-sm border border-gray-800 z-30;
         @apply animate-fadein;
 
         .plan-window-header {

--- a/app/resources/js/components/IslandEditor.vue
+++ b/app/resources/js/components/IslandEditor.vue
@@ -55,7 +55,7 @@
                     </template>
 
         </div>
-        <div v-show="showPlanWindow" class="plan-window" ref="planWindow"
+        <div v-show="showPlanWindow" class="plan-window"
              :style="[
                  { top: planWindowY + 'px'}, { left: planWindowX + 'px'}
              ]"

--- a/app/resources/js/components/IslandEditor.vue
+++ b/app/resources/js/components/IslandEditor.vue
@@ -205,10 +205,14 @@ export default {
             this.showPlanWindow = false;
         },
         onWindowSizeChanged() {
-            this.showHoverWindow = false;
-            this.showPlanWindow = false;
-            this.isMobile = (document.documentElement.clientWidth < 1024);
-            this.screenWidth = document.documentElement.clientWidth;
+            const newScreenWidth = document.documentElement.clientWidth;
+            if(this.screenWidth != newScreenWidth) {
+                this.screenWidth = newScreenWidth;
+                this.showHoverWindow = false;
+                console.log("windowSizeChanged");
+                this.showPlanWindow = false;
+                this.isMobile = (document.documentElement.clientWidth < 1024);
+            }
         }
     },
         computed: {

--- a/app/resources/js/components/IslandEditor.vue
+++ b/app/resources/js/components/IslandEditor.vue
@@ -57,8 +57,7 @@
         </div>
         <div v-show="showPlanWindow" class="plan-window" ref="planWindow"
              :style="[
-                 { top: planWindowY + 'px' },
-                 !isMobile || planWindowLeftSide ? { left: planWindowX + 'px' } : { right: planWindowX + 'px' }
+                 { top: planWindowY + 'px'}, { left: planWindowX + 'px'}
              ]"
         >
             <div class="plan-window-header">
@@ -107,7 +106,6 @@ export default {
             screenWidth: document.documentElement.clientWidth,
             planWindowY: 0,
             planWindowX: 0,
-            planWindowLeftSide: true,
             isMobile: (document.documentElement.clientWidth < 1024),
         }
     },


### PR DESCRIPTION
# Overview

fix #61, fix #63
スマホビューでPlanListが意図しない動作をしてしまい、操作に支障を来す問題を解決しました。

# Description

## #61 勝手にPlanListが消える

画面リサイズの際にbreakpointの判定のため `resize` イベント時に `onWindowSizeChanged()` が発火するようになっていたのですが、スマホの実機を使っているとスクロール時にアプリのナビゲーションバーが表示されたり隠れたりする関係で、頻繁にこのイベントが呼ばれてしまい、結果としてリサイズ時のリセット処理としてHoverWindow, PlanListが非表示になっていました。

`height` が頻繁に変更されるのが問題になるため、`width` を見て条件分岐するように設定しました。
ピンチイン・ピンチアウトで `width` が変わるのではないかという懸念があったため実験しましたが、これはズームされるだけで `document.screenWidth` は変更されないため問題にならないようです。

https://github.com/mjtakenon/hakoniwa/blob/a8694bbf4b78c2b28c96119be49abb1ae7597312/app/resources/js/components/IslandEditor.vue#L215-L223

## #63 スマホビューの一部画面比率の端末で、PlanListがはみ出る

ウィンドウを固定幅に変更し、HoverWindowと同様にタップ位置に対して垂直方向に展開されるように仕様を変更しました。また左右にはみ出た際の処理についてもHoverWindowと同様のものに変更してあります。

この実装により、`Width < 230px` の端末でない限りははみ出ることはなくなりました。
（とはいえ、そんな端末があったとしても今の時代にまともに使えたものではないので考慮する必要はないかもしれませんが…）

https://github.com/mjtakenon/hakoniwa/blob/a8694bbf4b78c2b28c96119be49abb1ae7597312/app/resources/js/components/IslandEditor.vue#L164-L178