### PR TITLE
島登録画面をBulma実装時と同様のデザインに修正

### DIFF
--- a/app/resources/css/app.scss
+++ b/app/resources/css/app.scss
@@ -85,19 +85,28 @@
         @apply mb-5 px-3 py-10 bg-success text-white rounded-md;
     }
 
-    .label {
-        @apply md:text-lg block mb-4 pb-2 border-b border-success;
-    }
+    .field {
+        @apply w-full;
 
-    .control {
-        @apply flex items-center mb-10;
-
-        .input {
-            @apply grow p-2 rounded-md border border-gray-400 mr-3 drop-shadow-md;
+        .label {
+            @apply md:text-lg block mb-4 pb-2 border-b border-success;
         }
 
-        .icon {
-            @apply text-lg;
+        .control {
+            @apply relative w-full items-center mb-10;
+
+            .icons {
+                @apply absolute flex items-center px-3 justify-between w-full h-full text-lg z-10 pointer-events-none;
+            }
+
+            .input, .input-with-icon {
+                @apply w-full px-3 py-2 rounded-md border border-gray-400 drop-shadow-md;
+                @apply focus:outline-2 focus:outline-success;
+            }
+
+            .input-with-icon {
+                @apply px-10;
+            }
         }
     }
 }

--- a/app/resources/views/pages/register.blade.php
+++ b/app/resources/views/pages/register.blade.php
@@ -8,13 +8,12 @@
             <div class="field">
                 <label class="label">島にどんな名前をつけますか?（最大32文字）</label>
                 <div class="control">
-                    <input id="island-name-input" class="input" type="text" name="island_name" placeholder="島名を入力してください" maxlength="32" minlength="1" required pattern=".*\S+.*">
-                    <span class="icon">
-                        🏝
-                    </span>
-                    <span class="icon">
-                        島
-                    </span>
+                    <div class="icons">
+                        <span>🏝</span>
+                        <span>島</span>
+                    </div>
+                    <input id="island-name-input" class="input-with-icon" type="text" name="island_name" placeholder="島名を入力してください" maxlength="32" minlength="1" required pattern=".*\S+.*">
+
                 </div>
 {{--                <p class="help is-success">この島名は利用可能です！</p>--}}
                 {{--                <p class="help is-success">名前は後から変更可能です</p>--}}
@@ -30,7 +29,9 @@
 
             <div class="field">
                 <div class="control">
-                    <input id="submit-button" class="button-primary mx-auto" type="submit" value="島を探しに行く"/>
+                    <div class="w-full text-center">
+                        <input id="submit-button" class="button-primary" type="submit" value="島を探しに行く"/>
+                    </div>
                 </div>
             </div>
         </form>


### PR DESCRIPTION
# Overview

島登録画面をBulma実装時と同様のデザインに修正しました。
![image](https://github.com/mjtakenon/hakoniwa/assets/130939038/c0f27df5-4fdf-4e48-a404-82e803715bb0)

# Description

Tailwindの移行時にregisterページのデザインを修正したのですが、以前のデザインと異なっていたため修正しました。
ご迷惑おかけして申し訳ありません 🙇