### PR TITLE
島編集画面での次ターンまでの残り時間表示

### DIFF
--- a/app/app/Http/Controllers/Islands/PlansController.php
+++ b/app/app/Http/Controllers/Islands/PlansController.php
@@ -76,7 +76,11 @@ class PlansController extends Controller
                     'name' => $targetIsland->name,
                     'owner_name' => $targetIsland->owner_name,
                 ];
-            })
+            }),
+            'turn' => [
+                'turn' => $turn->turn,
+                'next_time' => $turn->next_turn_scheduled_at->format('Y-m-d H:i:s')
+            ]
         ]);
     }
 

--- a/app/resources/js/components/CountdownWidget.vue
+++ b/app/resources/js/components/CountdownWidget.vue
@@ -8,8 +8,8 @@
             class="countdown-box rounded-bl-xl md:rounded-b-xl"
             :class="{'countdown-box-updated': !this.isTimeRemaining}"
         >
-            <span class="countdown-label mr-1">次の更新まで</span>
             <template v-if="isTimeRemaining">
+                <span class="countdown-label mr-1">次の更新まで</span>
                 <template v-if="remainTimes.hour > 0">
                     <span class="text-sm">{{ remainTimes.hour }}</span>
                     <span class="countdown-unit">時間</span>

--- a/app/resources/js/components/CountdownWidget.vue
+++ b/app/resources/js/components/CountdownWidget.vue
@@ -1,0 +1,108 @@
+<template>
+    <div id="countdown-widget">
+        <div class="countdown-box rounded-br-xl md:rounded-b-xl">
+            <span class="countdown-label mr-1">turn:</span>
+            <span class="text-sm">{{ store.turn.turn }}</span>
+        </div>
+        <div
+            class="countdown-box rounded-bl-xl md:rounded-b-xl"
+            :class="{'countdown-box-updated': !this.isTimeRemaining}"
+        >
+            <span class="countdown-label mr-1">次の更新まで</span>
+            <template v-if="isTimeRemaining">
+                <template v-if="remainTimes.hour > 0">
+                    <span class="text-sm">{{ remainTimes.hour }}</span>
+                    <span class="countdown-unit">時間</span>
+                </template>
+                <template v-if="remainTimes.hour > 0 || remainTimes.min > 0">
+                    <span class="text-sm">{{
+                            (remainTimes.min < 10 ? '0' + remainTimes.min : remainTimes.min.toString())
+                        }}</span>
+                    <span class="countdown-unit">分</span>
+                </template>
+                <span class="text-sm">{{
+                        (remainTimes.sec < 10 ? '0' + remainTimes.sec : remainTimes.sec.toString())
+                    }}</span>
+                <span class="countdown-unit">秒</span>
+            </template>
+            <template v-else>
+                <span class="text-sm">更新済み</span>
+            </template>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import {defineComponent} from "vue";
+import {useMainStore} from "../store/MainStore";
+
+export default defineComponent({
+    data() {
+        return {
+            remainTimes: {
+                hour: 0,
+                min: 0,
+                sec: 0
+            },
+            isTimeRemaining: true,
+            secInterval: null,
+        }
+    },
+    setup() {
+        const store = useMainStore();
+        return {store};
+    },
+    mounted() {
+        this.secInterval = setInterval(this.countDownTurn, 1000);
+    },
+    unmounted() {
+        clearInterval(this.secInterval);
+    },
+    methods: {
+        countDownTurn() {
+            const now = new Date();
+            if (now > this.store.turn.next_time) {
+                this.isTimeRemaining = false;
+                clearInterval(this.secInterval);
+            } else {
+                const diff = this.store.turn.next_time.getTime() - now.getTime();
+                const h = Math.floor(diff / 1000 / 60 / 60);
+                const m = Math.floor(diff / 1000 / 60) % 60;
+                const s = Math.floor(diff / 1000) % 60;
+                this.remainTimes = {
+                    hour: h,
+                    min: m,
+                    sec: s
+                };
+            }
+        }
+    }
+})
+</script>
+
+<style scoped lang="postcss">
+
+#countdown-widget {
+    @apply flex w-full justify-between h-6 mb-4 lg:mb-2 drop-shadow;
+
+    .countdown-box {
+        @apply inline-flex items-center px-2 bg-gray-300;
+    }
+
+    .countdown-box-updated {
+        @apply bg-danger-dark text-white;
+    }
+
+    .countdown-label {
+        @apply text-xs text-gray-600;
+    }
+
+    .countdown-unit {
+        @apply text-[8px] mt-auto mb-[2px] mr-1 text-gray-600;
+    }
+
+    .countdown-unit:last-child {
+        @apply mr-0
+    }
+}
+</style>

--- a/app/resources/js/components/IslandEditor.vue
+++ b/app/resources/js/components/IslandEditor.vue
@@ -25,6 +25,8 @@
             </div>
             <div class="left-padding" :class="{'opacity-80': this.showPlanWindow}" v-if="y%2 === 0"></div>
         </div>
+        <countdown-widget></countdown-widget>
+
         <div v-show="showHoverWindow" class="hover-window" :style="{ bottom: hoverWindowY+'px', left: hoverWindowX+'px' }">
             <div class="hover-window-header">
                 <img
@@ -35,22 +37,21 @@
                     {{ (getIslandTerrain(hoverCellPoint.x, hoverCellPoint.y).data.info) }}
                 </div>
             </div>
-                    <template v-for="(plan, index) of store.plans">
-                        <div class="hover-window-plan" v-if="
-                            plan.data.usePoint &&
-                            plan.data.point.x === hoverCellPoint.x &&
-                            plan.data.point.y === hoverCellPoint.y &&
-                            (!plan.data.useTargetIsland || plan.data.useTargetIsland && plan.data.targetIsland === store.island.id)
-                        ">
-                            <span>[{{ index + 1 }}] </span>
-                            <span>{{ plan.data.name }}</span>
-                            <span v-if="plan.data.useAmount">
-                                <span v-if="plan.data.amount === 0"> {{ plan.data.defaultAmountString }}</span>
-                                <span v-else> {{ plan.data.amountString.replace(':amount:', plan.data.amount.toString()) }} </span>
-                            </span>
-                        </div>
-                    </template>
-
+            <template v-for="(plan, index) of store.plans">
+                <div class="hover-window-plan" v-if="
+                    plan.data.usePoint &&
+                    plan.data.point.x === hoverCellPoint.x &&
+                    plan.data.point.y === hoverCellPoint.y &&
+                    (!plan.data.useTargetIsland || plan.data.useTargetIsland && plan.data.targetIsland === store.island.id)
+                ">
+                    <span>[{{ index + 1 }}] </span>
+                    <span>{{ plan.data.name }}</span>
+                    <span v-if="plan.data.useAmount">
+                        <span v-if="plan.data.amount === 0"> {{ plan.data.defaultAmountString }}</span>
+                        <span v-else> {{ plan.data.amountString.replace(':amount:', plan.data.amount.toString()) }} </span>
+                    </span>
+                </div>
+            </template>
         </div>
         <div v-show="showPlanWindow" class="plan-window"
              :style="[
@@ -84,12 +85,16 @@
 </template>
 
 <script lang="ts">
-import { Terrain } from "../store/Entity/Terrain";
+import {Terrain} from "../store/Entity/Terrain";
 import {Plan} from "../store/Entity/Plan";
 import {defineComponent} from "vue";
 import {useMainStore} from "../store/MainStore";
+import CountdownWidget from "./CountdownWidget.vue";
 
 export default defineComponent({
+    components: {
+        CountdownWidget
+    },
     data() {
         return {
             MAX_PLAN_NUMBER: 30,
@@ -119,7 +124,7 @@ export default defineComponent({
     },
     methods: {
         getIslandTerrain(x, y): Terrain {
-            return this.store.terrains.filter(function(item, idx){
+            return this.store.terrains.filter(function (item, idx) {
                 if (item.data.point.x === x && item.data.point.y === y) return true;
             }).pop();
         },
@@ -221,13 +226,13 @@ export default defineComponent({
         },
         onWindowSizeChanged() {
             const newScreenWidth = document.documentElement.clientWidth;
-            if(this.screenWidth != newScreenWidth) {
+            if (this.screenWidth != newScreenWidth) {
                 this.screenWidth = newScreenWidth;
                 this.showHoverWindow = false;
                 this.showPlanWindow = false;
                 this.isMobile = (document.documentElement.clientWidth < 1024);
             }
-        }
+        },
     },
         computed: {
             isSelectedCell() {
@@ -256,7 +261,7 @@ export default defineComponent({
 
 #island {
     margin: 0 auto;
-    @apply w-full md:min-w-[496px] max-w-[496px] mb-4;
+    @apply w-full md:min-w-[496px] max-w-[496px];
 
     .row {
         @apply m-0 p-0 bg-black;

--- a/app/resources/js/pages/PlanPage.vue
+++ b/app/resources/js/pages/PlanPage.vue
@@ -32,6 +32,7 @@ import {Status} from "../store/Entity/Status";
 import {Terrain} from "../store/Entity/Terrain";
 import {Plan} from "../store/Entity/Plan";
 import {Log} from "../store/Entity/Log";
+import {Turn} from "../store/Entity/Turn";
 
 export default defineComponent({
     components: {
@@ -62,6 +63,12 @@ export default defineComponent({
             })
         }
 
+        // turn.next_turnのDateオブジェクト変換
+        const turn: Turn = {
+            turn: props.turn.turn,
+            next_time: new Date(props.turn.next_time)
+        }
+
         // Pinia
         const store = useMainStore();
         store.$patch({
@@ -74,7 +81,8 @@ export default defineComponent({
             sentPlans: lodash.cloneDeep(props.island.plans),
             planCandidate: candidates,
             targetIslands: props.targetIslands,
-            selectedTargetIsland: props.island.id
+            selectedTargetIsland: props.island.id,
+            turn: turn
         });
         return {store}
     },
@@ -103,6 +111,13 @@ export default defineComponent({
         targetIslands: {
             required: true,
             type: Array as PropType<Island[]>
+        },
+        turn: {
+            required: true,
+            type: Object as PropType<{
+                turn: number,
+                next_time: string
+            }>
         }
     },
 });

--- a/app/resources/js/store/Entity/Turn.ts
+++ b/app/resources/js/store/Entity/Turn.ts
@@ -1,0 +1,4 @@
+export interface Turn {
+    turn: number,
+    next_time: Date
+}

--- a/app/resources/js/store/MainStore.ts
+++ b/app/resources/js/store/MainStore.ts
@@ -8,6 +8,7 @@ import {Log} from "./Entity/Log";
 import {Plan} from "./Entity/Plan";
 import axios from "axios";
 import {Point} from "./Entity/Point";
+import {Turn} from "./Entity/Turn";
 
 const ISLAND_ENVIRONMENT = {
     'best': '最高',
@@ -33,6 +34,7 @@ export interface PiniaState {
     planCandidate: Plan[],
     planSendingResult: number,
     showNotification: boolean,
+    turn: Turn
 }
 
 export const useMainStore = defineStore('main', {
@@ -66,6 +68,10 @@ export const useMainStore = defineStore('main', {
             planCandidate: [],
             planSendingResult: 200,
             showNotification: false,
+            turn: {
+                turn: 0,
+                next_time: new Date('1970/1/1 00:00:00')
+            }
         }
     },
     getters: {

--- a/app/resources/views/pages/islands/plans.blade.php
+++ b/app/resources/views/pages/islands/plans.blade.php
@@ -8,6 +8,7 @@
             :island="@js($island)"
             :plan-candidate="@js($executablePlans)"
             :target-islands="@js($targetIslands)"
+            :turn="@js($turn)"
         ></plan-page>
     </div>
 @endsection


### PR DESCRIPTION
# Overview

島編集画面のマップ下部に、次ターンまでのカウントダウンタイマーを実装しました。

![image](https://github.com/mjtakenon/hakoniwa/assets/130939038/b08aedba-3ba2-4983-9ba5-f6c7c517de0f)

# Description

ターン情報取得のため、Laravel側から新たにターン情報を渡しています。
不要な情報の受け渡しを避けるためにLaravel側でformatしています。
https://github.com/mjtakenon/hakoniwa/blob/0d55c5dbb11f4071ecdc457d2618627421dfaa65/app/app/Http/Controllers/Islands/PlansController.php#L80-L83

これをPropsに渡して、JavascriptのData型に変換後storeに格納しています。

また更新後になった場合、「更新済み」の表記に変わります。
![1ad9f27474e76ad113a0face0c22cfe7](https://github.com/mjtakenon/hakoniwa/assets/130939038/4e5f3cb7-2d98-4511-9944-191b7183cf91)
