### PR TITLE
スマホビューの時、計算誤差で1pxの黒い線が入る問題を修正

### DIFF
--- a/app/resources/js/components/IslandEditor.vue
+++ b/app/resources/js/components/IslandEditor.vue
@@ -259,7 +259,7 @@ export default defineComponent({
     @apply w-full md:min-w-[496px] max-w-[496px] mb-4;
 
     .row {
-        @apply m-0 p-0 bg-black;
+        @apply m-0 -mt-[0.1px] p-0 bg-black;
         display: grid;
 
         .cell {


### PR DESCRIPTION
# Overview

fix #73 
スマホビューの時に黒い線が入る問題を修正しました。

# Description

レスポンシブ対応時に、動的にマップのサイズが変わるように実装しましたが、画面サイズが特定のタイミングで黒い1pxの線が入るようになりました。

どうやらgridを並べるときにサイズの調整がうまくいかず、一部の列のサイズで縦幅の計算誤差が発生していたようです。
これを解消するために、rowをネガティブマージンで0.1px持ち上げることで解決しました。