### PR TITLE
ログ表示部を見やすいようにデザイン変更

### DIFF
--- a/app/resources/css/app.scss
+++ b/app/resources/css/app.scss
@@ -81,7 +81,7 @@
         @apply text-left w-full mt-10 mb-10 bg-gray-100 pb-4 rounded-2xl drop-shadow-md overflow-hidden;
 
         .subtitle {
-            @apply mt-0 py-3 px-3 align-middle border-b border-b-gray-300 mb-3 w-full bg-success-dark text-white;
+            @apply mt-0 py-3 px-3 border-b border-b-gray-300 mb-3 w-full bg-success-dark text-white;
         }
 
         .log-texts {

--- a/app/resources/css/app.scss
+++ b/app/resources/css/app.scss
@@ -76,6 +76,22 @@
 
 #index {
     @apply mx-auto max-w-[1000px] px-3;
+
+    #logs {
+        @apply text-left w-full mt-10 mb-10 bg-gray-100 pb-4 rounded-2xl drop-shadow-md overflow-hidden;
+
+        .subtitle {
+            @apply mt-0 py-3 px-3 align-middle border-b border-b-gray-300 mb-3 w-full bg-success-dark text-white;
+        }
+
+        .log-texts {
+            @apply text-sm md:text-base mx-1 md:mx-5 mb-1 lg:mb-0.5 border-b border-b-gray-300;
+        }
+
+        .log-texts:last-child {
+            @apply border-none;
+        }
+    }
 }
 
 #register {

--- a/app/resources/js/components/LogViewer.vue
+++ b/app/resources/js/components/LogViewer.vue
@@ -3,7 +3,7 @@
         <div class="subtitle">
             {{ store.island.name }}島の近況
         </div>
-        <div class="w-full" v-for="(log, index) of store.logs" :key="'log-' + index">
+        <div class="log-texts" v-for="(log, index) of store.logs" :key="'log-' + index">
             <span v-for="context of JSON.parse(log.log)" :key="context.text">
                 <a v-if="context.hasOwnProperty('link')" :href="context.link" :style="context.style">
                     {{ context.text }}
@@ -30,7 +30,19 @@ export default defineComponent({
 <style lang="postcss" scoped>
 
 #logs {
-    @apply text-left w-full px-3 mb-10
+    @apply text-left w-full mt-10 mb-10 bg-gray-100 pb-4 md:rounded-2xl drop-shadow-md overflow-hidden;
+
+    .subtitle {
+        @apply mt-0 py-3 px-3 align-middle border-b border-b-gray-300 mb-3 w-full bg-success-dark text-white;
+    }
+
+    .log-texts {
+        @apply text-sm md:text-base mx-1 md:mx-5 mb-1 lg:mb-0.5 border-b border-b-gray-300;
+    }
+
+    .log-texts:last-child {
+        @apply border-none;
+    }
 }
 
 </style>

--- a/app/resources/js/components/LogViewer.vue
+++ b/app/resources/js/components/LogViewer.vue
@@ -33,7 +33,7 @@ export default defineComponent({
     @apply text-left w-full mt-10 mb-10 bg-gray-100 pb-4 md:rounded-2xl drop-shadow-md overflow-hidden;
 
     .subtitle {
-        @apply mt-0 py-3 px-3 align-middle border-b border-b-gray-300 mb-3 w-full bg-success-dark text-white;
+        @apply mt-0 py-3 px-3 border-b border-b-gray-300 mb-3 w-full bg-success-dark text-white;
     }
 
     .log-texts {

--- a/app/resources/views/pages/index.blade.php
+++ b/app/resources/views/pages/index.blade.php
@@ -39,9 +39,8 @@
                 ></ranking-viewer>
             @endforeach
 
-            <div>
-                <h2 class="subtitle mt-20"> 最近の出来事 </h2>
-                <hr/>
+            <div id="logs">
+                <h2 class="subtitle"> 最近の出来事 </h2>
                 {{--                <div v-for="log of $store.state.logs" :key="log.id">--}}
                 {{--            <span v-for="context of JSON.parse(log.log)" :key="context.text">--}}
                 {{--                <a v-if="context.hasOwnProperty('link')" :href="context.link" :style="context.style">--}}
@@ -53,7 +52,7 @@
                 {{--            </span>--}}
                 {{--                </div>--}}
                 @foreach($logs as $log)
-                    <div>
+                    <div class="log-texts">
                         @foreach(json_decode($log->log) as $context)
                             <span>
                             @if(property_exists($context, 'link'))


### PR DESCRIPTION
# Overview

ログ表示部を見やすいようにデザイン変更しました。
特にスマホビューで読みづらい問題を解決しました。

# Description

ログ表示部の背景色を追加し、ヘッダーに色を付けました。
また各ログに対して下線を引くことで境界が分かりやすくなっています。
加えてスマホビューでのmargin微調整や、テキストサイズの修正を行い大幅に可読性が向上しました。

**Desktop**
![image](https://github.com/mjtakenon/hakoniwa/assets/130939038/6ebc3210-8cc8-4d4b-8b39-569d2e5ebed2)

**Smartphone**
![image](https://github.com/mjtakenon/hakoniwa/assets/130939038/72fa5938-6089-466d-a777-510b0738e85e)

# Others

まだログのテキスト関係には手を付けていませんが、テキストの色や表示方法を変更するにあたり、大幅にバックエンド側にも修正加える必要があります。
現在新機能の実装に伴いログ実装部を修正中とのことですので、一旦こちらの修正は保留します。