### PR TITLE
島編集画面のステータス数値のフォントサイズを動的に変更するよう修正

### DIFF
--- a/app/resources/js/components/StatusTable.vue
+++ b/app/resources/js/components/StatusTable.vue
@@ -33,7 +33,6 @@
 <script lang="ts">
 import {defineComponent} from "vue";
 import {useMainStore} from "../store/MainStore";
-import {$ref} from "vue/macros";
 
 export default defineComponent({
     data() {

--- a/app/resources/js/components/StatusTable.vue
+++ b/app/resources/js/components/StatusTable.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="stats" :ref="'aiueo'">
+    <div class="stats">
         <div
             v-for="(status, index) in statuses"
             class="stats-box"


### PR DESCRIPTION
# Overview

fix #84 
島編集画面で、スマホビューの時文字が溢れる問題を修正しました。
今まで数字が大きくなると読みづらかったので、`,` の区切りも追加しています。
JavascriptのNumber型の最大値、`9007199254740991` まで正常に動作します。
レイアウトも多少調整しています。

**Smartphone**
![smartphone.png](https://github.com/mjtakenon/hakoniwa/assets/130939038/c0e09ff7-2a4e-416d-9736-17cf135234f7)

**Desktop**
![desktop.png](https://github.com/mjtakenon/hakoniwa/assets/130939038/0f5ef3f0-9cbf-40af-a3ad-27556251fb4a)

# Description

特殊な方法でないと実装できないため、かなり大掛かりに修正しています。

Vueが完全にレンダリングされた後でないと、v-for内のrefを取得しようとしたときに参照先が見つからないため、$nextTickを使用してレンダリング後にサイズ調整がかかるように変更しています。

またサイズに関しては、環境によってフォントが違うことで横幅の計算が変わってしまうことから、`calcFontSize` にて仮のspanを生成してbodyにappendしたのちにサイズの計測、計算後に削除するように変更しています。
Tailwindのテキストサイズ関係のクラスが今回の用途では使いづらいため、styleで直指定しています。

スマホビューとデスクトップビューでレイアウトが変更される関係でmaxWidthの計算も異なるため、IslandEditorにあったウィンドウサイズ変更時の処理についても実装を移植しました。