### PR TITLE
dpx比が1.0以上のデバイスでテキストが小さくなりすぎる問題の修正

### DIFF
--- a/app/resources/js/components/CountdownWidget.vue
+++ b/app/resources/js/components/CountdownWidget.vue
@@ -80,7 +80,7 @@ export default defineComponent({
 })
 </script>
 
-<style scoped lang="postcss">
+<style scoped lang="scss">
 
 #countdown-widget {
     @apply flex w-full justify-between h-6 mb-4 lg:mb-2 drop-shadow;
@@ -98,11 +98,11 @@ export default defineComponent({
     }
 
     .countdown-unit {
-        @apply text-[8px] mt-auto mb-[2px] mr-1 text-on-surface-variant;
+        @apply text-[0.5rem] mt-auto mb-0.5 mr-1 text-on-surface-variant;
     }
 
     .countdown-unit:last-child {
-        @apply mr-0
+        @apply mr-0;
     }
 }
 </style>

--- a/app/resources/js/components/LogViewer.vue
+++ b/app/resources/js/components/LogViewer.vue
@@ -215,7 +215,7 @@ export default defineComponent({
                     @apply w-full flex items-center px-0.5 border-b-2;
 
                     .summary-box-title {
-                        @apply text-on-surface-variant text-[6px] mr-1;
+                        @apply text-on-surface-variant text-[0.6rem] mr-1;
                     }
 
                     .summary-box-num {
@@ -223,7 +223,7 @@ export default defineComponent({
                     }
 
                     .summary-box-unit {
-                        @apply text-on-surface-variant text-[6px] ml-1 text-right;
+                        @apply text-on-surface-variant text-[0.6rem] ml-1 text-right;
                     }
                 }
             }

--- a/app/resources/js/components/StatusTable.vue
+++ b/app/resources/js/components/StatusTable.vue
@@ -177,7 +177,7 @@ export default defineComponent({
             @apply flex items-end flex-wrap h-8;
 
             .stats-box-num-wrapper {
-                @apply grow h-[27px] text-right;
+                @apply grow text-right;
             }
 
             .stats-box-data-num {
@@ -185,7 +185,7 @@ export default defineComponent({
             }
 
             .stat-box-data-unit {
-                @apply max-lg:w-full max-lg:-mt-1.5 text-[4px] lg:text-sm text-right lg:pl-2;
+                @apply max-lg:w-full max-lg:-mt-1.5 text-[0.6rem] lg:text-sm text-right lg:pl-2;
             }
         }
     }


### PR DESCRIPTION
# Overview

Device Pixel Ratioが1.0以上の端末で開いたとき、font-sizeの指定でpx単位で指定している箇所が小さくなりすぎるバグを修正しました。

# Description

特にiOS・Android端末でfont-sizeの指定に限り、dpx比>1の端末でフォントサイズが予期せぬサイズになっていました。
他の要素についてはきちんとスケーリングされて表示されるため、rem指定でなくても問題ないようです。
一旦全てのVueコンポーネントのfont-sizeがpx指定になっている箇所を修正しましたが、他にもまた問題が見つかれば修正します。