### PR TITLE
Controllerの中でAPIを分離、未ログイン時のAPIは403を返すよう修正

### DIFF
--- a/app/app/Http/Controllers/Api/Islands/DetailController.php
+++ b/app/app/Http/Controllers/Api/Islands/DetailController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers\Api\Islands;
+
+use App\Entity\Log\LogVisibility;
+use App\Http\Controllers\Api\WebApi;
+use App\Http\Controllers\Controller;
+use App\Models\Island;
+use App\Models\IslandLog;
+use App\Models\IslandStatus;
+use App\Models\Turn;
+use Illuminate\Support\Collection;
+
+class DetailController extends Controller
+{
+    use WebApi;
+    public function get($islandId) {
+        /** @var Island $island */
+        $island = Island::find($islandId);
+
+        if (is_null($island) || !is_null($island->deleted_at)) {
+            return $this->notFound();
+        }
+
+        $turn = Turn::latest()->firstOrFail();
+        $islandTerrain = $island->islandTerrains->where('turn_id', $turn->id)->firstOrFail();
+
+        return $this->ok([
+            'island' => [
+                'id' => $island->id,
+                'name' => $island->name,
+                'owner_name' => $island->owner_name,
+                'terrains' => $islandTerrain->toEntity()->toArray(false, true),
+            ]
+        ]);
+    }
+}

--- a/app/app/Http/Controllers/Api/Islands/PlansController.php
+++ b/app/app/Http/Controllers/Api/Islands/PlansController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers\Api\Islands;
+
+use App\Entity\Plan\Plans;
+use App\Http\Controllers\Api\WebApi;
+use App\Http\Controllers\Controller;
+use App\Models\Island;
+use App\Models\Turn;
+
+class PlansController extends Controller
+{
+    use WebApi;
+    public function put(int $islandId): \Illuminate\Http\JsonResponse
+    {
+        $validator = \Validator::make(\Request::all(), [
+            'plan' => 'string|required',
+        ]);
+
+        if ($validator->fails()) {
+            return $this->badRequest();
+        }
+
+        if (!\HakoniwaService::isIslandRegistered() || \Auth::user()->island->id !== $islandId) {
+            return $this->forbidden();
+        }
+
+        $island = Island::find($islandId);
+
+        if (is_null($island) || !is_null($island->deleted_at)) {
+            return $this->notFound();
+        }
+
+        $validated = $validator->safe()->collect();
+
+        $turn = Turn::latest()->firstOrFail();
+
+        $plan = $validated->get('plan');
+
+        if (!\PlanService::isValidPlans($plan)) {
+            return $this->badRequest();
+        }
+
+        $plans = Plans::fromJson($plan);
+
+        $islandPlan = $island->islandPlans->where('turn_id', $turn->id)->first();
+
+        $islandPlan->plan = $plans->toJson();
+        $islandPlan->save();
+
+        return $this->ok(['plan' => $plans->toArray(true)]);
+    }
+}

--- a/app/app/Http/Controllers/Api/WebApi.php
+++ b/app/app/Http/Controllers/Api/WebApi.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Trait;
+namespace App\Http\Controllers\Api;
 trait WebApi {
     function ok(array $data = [], int $status = 200, array $headers = [], int $options = 0): \Illuminate\Http\JsonResponse
     {

--- a/app/app/Http/Controllers/Web/Accounts/IndexController.php
+++ b/app/app/Http/Controllers/Web/Accounts/IndexController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Accounts;
+namespace App\Http\Controllers\Web\Accounts;
 
 use App\Http\Controllers\Controller;
 

--- a/app/app/Http/Controllers/Web/Auth/Google/CallbackController.php
+++ b/app/app/Http/Controllers/Web/Auth/Google/CallbackController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Auth\Google;
+namespace App\Http\Controllers\Web\Auth\Google;
 
 use App\Http\Controllers\Controller;
 use App\Models\User;

--- a/app/app/Http/Controllers/Web/Auth/Google/RedirectController.php
+++ b/app/app/Http/Controllers/Web/Auth/Google/RedirectController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Auth\Google;
+namespace App\Http\Controllers\Web\Auth\Google;
 
 use App\Http\Controllers\Controller;
 

--- a/app/app/Http/Controllers/Web/Auth/YahooJapan/CallbackController.php
+++ b/app/app/Http/Controllers/Web/Auth/YahooJapan/CallbackController.php
@@ -1,13 +1,11 @@
 <?php
 
-namespace App\Http\Controllers\Auth\YahooJapan;
+namespace App\Http\Controllers\Web\Auth\YahooJapan;
 
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Models\UserAuthentication;
 use Illuminate\Support\Str;
-use YConnect\Credential\ClientCredential;
-use YConnect\YConnectClient;
 
 class CallbackController extends Controller
 {

--- a/app/app/Http/Controllers/Web/Auth/YahooJapan/RedirectController.php
+++ b/app/app/Http/Controllers/Web/Auth/YahooJapan/RedirectController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Auth\YahooJapan;
+namespace App\Http\Controllers\Web\Auth\YahooJapan;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Str;

--- a/app/app/Http/Controllers/Web/Help/IndexController.php
+++ b/app/app/Http/Controllers/Web/Help/IndexController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Help;
+namespace App\Http\Controllers\Web\Help;
 
 use App\Http\Controllers\Controller;
 

--- a/app/app/Http/Controllers/Web/Islands/BbsController.php
+++ b/app/app/Http/Controllers/Web/Islands/BbsController.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace App\Http\Controllers\Islands;
+namespace App\Http\Controllers\Web\Islands;
 
 use App\Http\Controllers\Controller;
+
 class BbsController extends Controller
 {
     public function get() {

--- a/app/app/Http/Controllers/Web/Islands/DetailController.php
+++ b/app/app/Http/Controllers/Web/Islands/DetailController.php
@@ -1,9 +1,8 @@
 <?php
 
-namespace App\Http\Controllers\Islands;
+namespace App\Http\Controllers\Web\Islands;
 
 use App\Entity\Log\LogVisibility;
-use App\Entity\Terrain\Terrain;
 use App\Http\Controllers\Controller;
 use App\Models\Island;
 use App\Models\IslandLog;

--- a/app/app/Http/Controllers/Web/Logout/IndexController.php
+++ b/app/app/Http/Controllers/Web/Logout/IndexController.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace App\Http\Controllers\Logout;
+namespace App\Http\Controllers\Web\Logout;
 
 use App\Http\Controllers\Controller;
+
 class IndexController extends Controller
 {
     public function post() {

--- a/app/app/Http/Controllers/Web/Register/IndexController.php
+++ b/app/app/Http/Controllers/Web/Register/IndexController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Register;
+namespace App\Http\Controllers\Web\Register;
 
 use App\Entity\Log\IslandFoundLog;
 use App\Entity\Plan\Plans;

--- a/app/app/Http/Middleware/Authenticate.php
+++ b/app/app/Http/Middleware/Authenticate.php
@@ -2,10 +2,13 @@
 
 namespace App\Http\Middleware;
 
+use App\Http\Controllers\Api\WebApi;
 use Illuminate\Auth\Middleware\Authenticate as Middleware;
 
 class Authenticate extends Middleware
 {
+    use WebApi;
+
     /**
      * Get the path the user should be redirected to when they are not authenticated.
      *
@@ -14,6 +17,10 @@ class Authenticate extends Middleware
      */
     protected function redirectTo($request)
     {
+        if ($request->is('api/*')) {
+            $this->forbidden()->throwResponse();
+        }
+
         if (! $request->expectsJson()) {
             return route('login',[],false);
         }

--- a/app/resources/js/store/MainStore.ts
+++ b/app/resources/js/store/MainStore.ts
@@ -110,9 +110,9 @@ export const useMainStore = defineStore('main', {
     },
     actions: {
         async putPlan() {
-            console.debug('PUT', '/islands/' + this.island.id + '/plans')
+            console.debug('PUT', '/api/islands/' + this.island.id + '/plans')
             await axios.put(
-                '/islands/' + this.island.id + '/plans',
+                '/api/islands/' + this.island.id + '/plans',
                 {
                     plan: JSON.stringify(this.plans),
                 }

--- a/app/routes/api.php
+++ b/app/routes/api.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -14,6 +13,25 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
-    return $request->user();
+//
+//Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
+//    return $request->user();
+//});
+
+$baseMiddleware = [
+    \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+    \Illuminate\Session\Middleware\StartSession::class,
+    \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+    \Illuminate\Http\Middleware\FrameGuard::class,
+    'auth:sanctum',
+];
+
+Route::prefix('/islands')->middleware($baseMiddleware)->group( function() {
+    Route::get('{island_id}', [\App\Http\Controllers\Api\Islands\DetailController::class, 'get'])
+        ->where('island_id', '[0-9]+');
+
+    Route::middleware(['auth:sanctum'])->group(function() {
+        Route::put('{island_id}/plans', [\App\Http\Controllers\Api\Islands\PlansController::class, 'put'])
+            ->where('island_id', '[0-9]+');
+    });
 });

--- a/app/routes/web.php
+++ b/app/routes/web.php
@@ -25,44 +25,35 @@ Route::prefix('/')->middleware(array_merge($baseMiddleware))->group( function() 
 });
 
 Route::prefix('/islands')->middleware(array_merge($baseMiddleware))->group( function() {
-    Route::get('{island_id}', [\App\Http\Controllers\Islands\DetailController::class, 'get'])
+    Route::get('{island_id}', [\App\Http\Controllers\Web\Islands\DetailController::class, 'get'])
         ->where('island_id', '[0-9]+');
 });
 
 Route::prefix('/islands')->middleware($baseMiddleware)->group( function() {
 
     Route::middleware(['auth:sanctum'])->group(function() {
-        Route::get('{island_id}/plans', [\App\Http\Controllers\Islands\PlansController::class, 'get'])
-            ->where('island_id', '[0-9]+');
-        Route::put('{island_id}/plans', [\App\Http\Controllers\Islands\PlansController::class, 'put'])
+        Route::get('{island_id}/plans', [\App\Http\Controllers\Web\Islands\PlansController::class, 'get'])
             ->where('island_id', '[0-9]+');
     });
-
 //    Route::get('{island_id}/bbs', [\App\Http\Controllers\Islands\BbsController::class, 'get']);
 //    Route::post('{island_id}/bbs', [\App\Http\Controllers\Islands\BbsController::class, 'post']);
 });
 
 Route::prefix('/register')->middleware(array_merge($baseMiddleware, ['auth:sanctum']))->group( function() {
-    Route::get('', [\App\Http\Controllers\Register\IndexController::class, 'get']);
-    Route::post('', [\App\Http\Controllers\Register\IndexController::class, 'post']);
+    Route::get('', [\App\Http\Controllers\Web\Register\IndexController::class, 'get']);
+    Route::post('', [\App\Http\Controllers\Web\Register\IndexController::class, 'post']);
 });
 
 Route::prefix('/logout')->middleware(array_merge($baseMiddleware))->group( function() {
-    Route::post('', [\App\Http\Controllers\Logout\IndexController::class, 'post']);
+    Route::post('', [\App\Http\Controllers\Web\Logout\IndexController::class, 'post']);
 });
 
 Route::prefix('/auth/google/')->middleware(array_merge($baseMiddleware, []))->group( function() {
-    Route::get('redirect', [\App\Http\Controllers\Auth\Google\RedirectController::class, 'get'])->name('login');
-    Route::get('callback', [\App\Http\Controllers\Auth\Google\CallbackController::class, 'get']);
+    Route::get('redirect', [\App\Http\Controllers\Web\Auth\Google\RedirectController::class, 'get'])->name('login');
+    Route::get('callback', [\App\Http\Controllers\Web\Auth\Google\CallbackController::class, 'get']);
 });
 
 Route::prefix('/auth/yahoo/')->middleware(array_merge($baseMiddleware, []))->group( function () {
-    Route::get('redirect', [\App\Http\Controllers\Auth\YahooJapan\RedirectController::class, 'get']);
-    Route::get('callback', [\App\Http\Controllers\Auth\YahooJapan\CallbackController::class, 'get']);
+    Route::get('redirect', [\App\Http\Controllers\Web\Auth\YahooJapan\RedirectController::class, 'get']);
+    Route::get('callback', [\App\Http\Controllers\Web\Auth\YahooJapan\CallbackController::class, 'get']);
 });
-
-Route::prefix('/test/')->group( function() {
-    Route::get('{id}', [\App\Http\Controllers\Test\DetailController::class, 'get']);
-});
-
-//, ['auth:sanctum']


### PR DESCRIPTION
## 概要

- 島の地形のみをJSONで取得するAPI、`GET /api/islands/{island_id}`を追加しました。
- 計画送信API`PUT /islands/{island_id}/plans`は、`PUT /api/islands/{island_id}/plans`にリネームしました。
- 未ログイン時は403レスポンスを返すように修正しました。

