### PR TITLE
md:max-lgの時のレイアウト変更、島名が長い時にフォントサイズを縮小

### DIFF
--- a/app/resources/js/components/RankingViewer.vue
+++ b/app/resources/js/components/RankingViewer.vue
@@ -8,11 +8,21 @@
         <div class="ranking">
             <div class="ranking-index">
                 <div class="ranking-index-num">{{ $props.index }}</div>
-                <div class="ranking-index-name" v-if="$props.island.abandoned_turn >= 1">{{ $props.island.name }}島 ({{ $props.island.abandoned_turn }})</div>
-                <div class="ranking-index-name" v-else>{{ $props.island.name }}島</div>
+                <div v-if="$props.island.abandoned_turn >= 1"
+                     class="ranking-index-name"
+                     :class="islandNameSize"
+                >
+                    {{ $props.island.name }}島 ({{ $props.island.abandoned_turn }})
+                </div>
+                <div v-else
+                     class="ranking-index-name"
+                     :class="islandNameSize"
+                >
+                    {{ $props.island.name }}島
+                </div>
             </div>
             <div class="ranking-summary">
-                <div class="pl-1 pr-3 md:border-r-2">
+                <div class="ranking-summary-wrapper">
                     <div class="ranking-summary-title">発展ポイント</div>
                     <div class="ranking-summary-data">
                         <div
@@ -21,7 +31,7 @@
                         <div class="ranking-summary-data-unit">pts</div>
                     </div>
                 </div>
-                <div class="pl-1 md:pr-3 md:border-r-2">
+                <div class="ranking-summary-wrapper">
                     <div class="ranking-summary-title">人口</div>
                     <div class="ranking-summary-data">
                         <div
@@ -30,7 +40,7 @@
                         <div class="ranking-summary-data-unit">人</div>
                     </div>
                 </div>
-                <div class="pl-1 pr-3 md:border-r-2">
+                <div class="ranking-summary-wrapper">
                     <div class="ranking-summary-title">資金</div>
                     <div class="ranking-summary-data">
                         <div
@@ -39,7 +49,7 @@
                         <div class="ranking-summary-data-unit">億円</div>
                     </div>
                 </div>
-                <div class="pl-1 md:pr-3 md:border-r-2">
+                <div class="ranking-summary-wrapper">
                     <div class="ranking-summary-title">食料</div>
                     <div class="ranking-summary-data">
                         <div
@@ -48,7 +58,7 @@
                         <div class="ranking-summary-data-unit">㌧</div>
                     </div>
                 </div>
-                <div class="pl-1 pr-3">
+                <div class="ranking-summary-wrapper">
                     <div class="ranking-summary-title">資源</div>
                     <div class="ranking-summary-data">
                         <div
@@ -83,7 +93,19 @@ export default defineComponent({
         });
         this.observer.observe(target);
     },
-
+    computed: {
+        islandNameSize(){
+            const nameSize = this.$props.island.name.length
+            if(nameSize > 24) {
+                return "text-xs"
+            }
+            else if (nameSize > 16){
+                return "text-sm"
+            } else {
+                return "text-base"
+            }
+        }
+    },
     methods: {
         onAppeared() {
             this.isAppeared = true;
@@ -124,7 +146,7 @@ export default defineComponent({
     @apply flex flex-wrap mb-3 p-0 rounded-xl border bg-surface drop-shadow-md text-on-surface;
 
     .ranking-index {
-        @apply px-3 inline-flex items-center border-surface-variant;
+        @apply px-3 inline-flex items-center border-on-surface-variant;
         @apply max-md:w-full max-md:py-2;
         @apply max-md:border-b-2 md:border-r-2 md:w-1/4;
 
@@ -133,22 +155,33 @@ export default defineComponent({
         }
 
         .ranking-index-name {
-            @apply grow font-black text-center text-lg text-on-link;
+            @apply grow font-black text-center text-on-link;
         }
     }
 
     .ranking-summary {
-        @apply grow pl-1 pr-3 py-1 grid grid-cols-2 md:grid-cols-5;
+        @apply grow pl-1 pr-3 py-1 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5;
 
         .ranking-summary-title {
             @apply font-bold text-on-surface-variant text-xs underline;
+        }
+
+        .ranking-summary-wrapper {
+            @apply pl-1 pr-3 md:border-r;
+        }
+
+        .ranking-summary-wrapper:nth-of-type(3) {
+            @apply md:max-lg:border-none;
+        }
+        .ranking-summary-wrapper:nth-of-type(5) {
+            @apply md:border-none;
         }
 
         .ranking-summary-data {
             @apply flex items-end;
 
             .ranking-summary-data-num {
-                @apply grow text-lg inline-block text-right font-bold mr-2;
+                @apply grow text-base md:text-sm lg:text-lg inline-block text-right font-bold mr-2;
             }
 
             .ranking-summary-data-unit {
@@ -157,5 +190,7 @@ export default defineComponent({
         }
     }
 }
+
+
 
 </style>


### PR DESCRIPTION
# Overview

ランキング表示のレイアウトで、mdかつlgの直前の場合、開発ポイントなどが数千万ptsを超えた場合レイアウトが崩れていたのを修正しました。

# Description

具体的には以下2点の修正を行いました。
- **画面サイズがmd以上lg未満の時、gridのレイアウトを横3列に変更・フォントサイズの変更**
  - 今回の主要な修正です。一部の場合においてレイアウトを変えることで文字が溢れるのを防ぎます。
- **当該箇所についてCSSのクラス化を行い、`nth-of-type`で指定するようにリファクタ**
- **島名の文字長に応じて文字サイズの調整**
  - 上記2点の修正時に発見したのですが、文字サイズを小さくしないとステータス表示の下に不自然な余白ができてしまうため修正を行いました。

![image](https://github.com/mjtakenon/hakoniwa/assets/130939038/e54d8815-2532-4c8d-b28e-990f4994fc68)
