### PR TITLE
オーナーコメントの変更APIと取得部分のコントローラを実装

### DIFF
--- a/app/app/Http/Controllers/Api/Islands/CommentsController.php
+++ b/app/app/Http/Controllers/Api/Islands/CommentsController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Api\Islands;
+
+use App\Http\Controllers\Api\WebApi;
+use App\Models\Island;
+use App\Models\IslandComment;
+
+class CommentsController
+{
+
+    use WebApi;
+    public function post(int $islandId): \Illuminate\Http\JsonResponse
+    {
+        $validator = \Validator::make(\Request::all(), [
+            'comment' => 'string|required|max:128',
+        ]);
+
+        if ($validator->fails()) {
+            return $this->badRequest();
+        }
+
+        if (!\HakoniwaService::isIslandRegistered() || \Auth::user()->island->id !== $islandId) {
+            return $this->forbidden();
+        }
+
+        $island = Island::find($islandId);
+
+        if (is_null($island) || !is_null($island->deleted_at)) {
+            return $this->notFound();
+        }
+
+        $validated = $validator->safe()->collect();
+
+        $comment = $validated->get('comment');
+
+        return \DB::transaction(function () use ($island, $comment) {
+
+            $island->islandComments->each(function ($oldIslandComment) {
+                $oldIslandComment->delete();
+            });
+
+            $islandComment = new IslandComment();
+            $islandComment->island_id = $island->id;
+            $islandComment->comment = $comment;
+            $islandComment->save();
+
+            return $this->ok(['comment' => $islandComment->comment]);
+        });
+    }
+}

--- a/app/app/Http/Controllers/IndexController.php
+++ b/app/app/Http/Controllers/IndexController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Entity\Log\LogConst;
 use App\Models\Island;
+use App\Models\IslandComment;
 use App\Models\IslandLog;
 use App\Models\IslandStatus;
 use App\Models\Turn;
@@ -18,8 +19,8 @@ class IndexController extends Controller
 
         $islands = Island::select('*', 'islands.id as id')
             ->where('turn_id', $turn->id)
-            ->whereNull('deleted_at')
             ->join('island_statuses','islands.id','=','island_statuses.island_id')
+            ->leftJoin('island_comments','islands.id','=','island_comments.island_id')
             ->orderBy('island_statuses.development_points', 'desc')
             ->get();
 
@@ -42,11 +43,12 @@ class IndexController extends Controller
 
         return view('pages.index', [
             'islands' => $islands->map(function ($island) {
-                /** @var Island | IslandStatus $island */
+                /** @var Island | IslandStatus | IslandComment $island */
                 return [
                     'id' => $island->id,
                     'name' => $island->name,
                     'owner_name' => $island->owner_name,
+                    'comment' => $island->comment,
                     'development_points' => $island->development_points,
                     'funds' => $island->funds,
                     'foods' => $island->foods,

--- a/app/app/Http/Controllers/Web/Islands/DetailController.php
+++ b/app/app/Http/Controllers/Web/Islands/DetailController.php
@@ -26,6 +26,7 @@ class DetailController extends Controller
 
         $islandStatus = $island->islandStatuses->where('turn_id', $turn->id)->firstOrFail();
         $islandTerrain = $island->islandTerrains->where('turn_id', $turn->id)->firstOrFail();
+        $islandComment = $island->islandComments->first();
         $islandLogs = $island->islandLogs()
             ->whereIn('turn_id', Turn::where('turn', '>=', $turn->turn - self::DEFAULT_SHOW_LOG_TURNS)->get('id'))
             ->whereIn('visibility', [LogConst::VISIBILITY_GLOBAL, LogConst::VISIBILITY_PUBLIC])
@@ -59,6 +60,7 @@ class DetailController extends Controller
                 'id' => $island->id,
                 'name' => $island->name,
                 'owner_name' => $island->owner_name,
+                'comment' => $islandComment->comment ?? null,
                 'status' => [
                     'development_points' => $islandStatus->development_points,
                     'funds' => $islandStatus->funds,

--- a/app/app/Http/Controllers/Web/Islands/PlansController.php
+++ b/app/app/Http/Controllers/Web/Islands/PlansController.php
@@ -32,6 +32,7 @@ class PlansController extends Controller
         $islandPlans = $island->islandPlans->where('turn_id', $turn->id)->firstOrFail();
         $islandStatus = $island->islandStatuses->where('turn_id', $turn->id)->firstOrFail();
         $islandTerrain = $island->islandTerrains->where('turn_id', $turn->id)->firstOrFail();
+        $islandComment = $island->islandComments->first();
         $islandLogs = $island->islandLogs()
             ->whereIn('turn_id', Turn::where('turn', '>=', $turn->turn - $getLogRecentTurns)->get('id'))
             ->with(['turn'])
@@ -67,6 +68,7 @@ class PlansController extends Controller
                 'id' => $island->id,
                 'name' => $island->name,
                 'owner_name' => $island->owner_name,
+                'comment' => $islandComment->comment ?? null,
                 'status' => [
                     'development_points' => $islandStatus->development_points,
                     'funds' => $islandStatus->funds,

--- a/app/app/Models/Island.php
+++ b/app/app/Models/Island.php
@@ -18,14 +18,16 @@ class Island extends Model
     /**
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function islandStatuses() {
+    public function islandStatuses(): \Illuminate\Database\Eloquent\Relations\HasMany
+    {
         return $this->hasMany(IslandStatus::class);
     }
 
     /**
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function orderByDevelopmentPoints() {
+    public function orderByDevelopmentPoints(): \Illuminate\Database\Eloquent\Relations\HasMany
+    {
         return $this->hasMany(IslandStatus::class)
             ->orderBy('development_points', 'desc');
     }
@@ -33,28 +35,40 @@ class Island extends Model
     /**
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function islandTerrains() {
+    public function islandTerrains(): \Illuminate\Database\Eloquent\Relations\HasMany
+    {
         return $this->hasMany(IslandTerrain::class);
     }
 
     /**
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function islandPlans() {
+    public function islandPlans(): \Illuminate\Database\Eloquent\Relations\HasMany
+    {
         return $this->hasMany(IslandPlan::class);
     }
 
     /**
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function islandLogs() {
+    public function islandLogs(): \Illuminate\Database\Eloquent\Relations\HasMany
+    {
         return $this->hasMany(IslandLog::class);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function islandComments(): \Illuminate\Database\Eloquent\Relations\HasMany
+    {
+        return $this->hasMany(IslandComment::class);
     }
 
     /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function user() {
+    public function user(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    {
         return $this->belongsTo(User::class);
     }
 }

--- a/app/app/Models/IslandComment.php
+++ b/app/app/Models/IslandComment.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class IslandComment extends Model
+{
+    use SoftDeletes;
+    use HasFactory;
+
+    const UPDATED_AT = null;
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function island() {
+        return $this->belongsTo(Island::class);
+    }
+}

--- a/app/database/factories/IslandFactory.php
+++ b/app/database/factories/IslandFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
+ */
+class IslandFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'user_id' => $this->faker->randomNumber(),
+            'name' => $this->faker->name,
+            'owner_name' => $this->faker->name,
+        ];
+    }
+
+    public function setUser(User $user): Factory {
+        return $this->state(function () use ($user) {
+            return [
+                'user_id' => $user->id,
+            ];
+        });
+    }
+}

--- a/app/database/factories/UserFactory.php
+++ b/app/database/factories/UserFactory.php
@@ -19,22 +19,6 @@ class UserFactory extends Factory
     {
         return [
             'name' => fake()->name(),
-            'email' => fake()->unique()->safeEmail(),
-//            'email_verified_at' => now(),
-//            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
-//            'remember_token' => Str::random(10),
         ];
-    }
-
-    /**
-     * Indicate that the model's email address should be unverified.
-     *
-     * @return static
-     */
-    public function unverified()
-    {
-        return $this->state(fn (array $attributes) => [
-            'email_verified_at' => null,
-        ]);
     }
 }

--- a/app/database/migrations/2023_05_20_0220301_create_island_comments.php
+++ b/app/database/migrations/2023_05_20_0220301_create_island_comments.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('island_comments', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('island_id');
+            $table->string('comment', 128);
+            $table->datetime('created_at')->index();
+            $table->softDeletes();
+
+            $table->index(['island_id', 'deleted_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('island_comments');
+    }
+};

--- a/app/phpunit.xml
+++ b/app/phpunit.xml
@@ -1,31 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true"
->
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit</directory>
-        </testsuite>
-        <testsuite name="Feature">
-            <directory suffix="Test.php">./tests/Feature</directory>
-        </testsuite>
-    </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">./app</directory>
-        </include>
-    </coverage>
-    <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="BCRYPT_ROUNDS" value="4"/>
-        <env name="CACHE_DRIVER" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
-        <env name="MAIL_MAILER" value="array"/>
-        <env name="QUEUE_CONNECTION" value="sync"/>
-        <env name="SESSION_DRIVER" value="array"/>
-        <env name="TELESCOPE_ENABLED" value="false"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/Unit</directory>
+    </testsuite>
+    <testsuite name="Feature">
+      <directory suffix="Test.php">./tests/Feature</directory>
+    </testsuite>
+  </testsuites>
+  <coverage/>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+    <env name="BCRYPT_ROUNDS" value="4"/>
+    <env name="CACHE_DRIVER" value="array"/>
+    <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
+    <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+    <env name="MAIL_MAILER" value="array"/>
+    <env name="QUEUE_CONNECTION" value="sync"/>
+    <env name="SESSION_DRIVER" value="array"/>
+    <env name="TELESCOPE_ENABLED" value="false"/>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">./app</directory>
+    </include>
+  </source>
 </phpunit>

--- a/app/routes/api.php
+++ b/app/routes/api.php
@@ -26,12 +26,13 @@ $baseMiddleware = [
     'auth:sanctum',
 ];
 
-Route::prefix('/islands')->middleware($baseMiddleware)->group( function() {
-    Route::get('{island_id}', [\App\Http\Controllers\Api\Islands\DetailController::class, 'get'])
+Route::prefix('/islands/{island_id}')->middleware($baseMiddleware)->group( function() {
+    Route::get('/', [\App\Http\Controllers\Api\Islands\DetailController::class, 'get'])
         ->where('island_id', '[0-9]+');
 
-    Route::middleware(['auth:sanctum'])->group(function() {
-        Route::put('{island_id}/plans', [\App\Http\Controllers\Api\Islands\PlansController::class, 'put'])
-            ->where('island_id', '[0-9]+');
-    });
+    Route::put('/plans', [\App\Http\Controllers\Api\Islands\PlansController::class, 'put'])
+        ->where('island_id', '[0-9]+');
+
+    Route::post('/comments', [\App\Http\Controllers\Api\Islands\CommentsController::class, 'post'])
+        ->where('island_id', '[0-9]+');
 });

--- a/app/tests/App/Http/Controllers/Api/Islands/CommentsControllerTest.php
+++ b/app/tests/App/Http/Controllers/Api/Islands/CommentsControllerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\App\Http\Controllers\Api\Islands;
+
+use App\Models\Island;
+use App\Models\IslandComment;
+use App\Models\User;
+use Tests\TestCase;
+
+class CommentsControllerTest extends TestCase
+{
+    public function testPostSuccess()
+    {
+        $user = User::factory()->create();
+        $island = Island::factory()->setUser($user)->create();
+
+        $response = $this->actingAs($user)
+            ->post('/api/islands/' . $island->id . '/comments', [
+                'comment' => 'test_comment',
+            ]);
+
+        $response->assertOk();
+        $this->assertNotNull(IslandComment::find(1));
+        $this->assertSame('test_comment', IslandComment::find(1)->comment);
+
+        $response = $this->actingAs($user)
+            ->post('/api/islands/' . $island->id . '/comments', [
+                'comment' => 'test_comment2',
+            ]);
+
+        $response->assertOk();
+        $this->assertNull(IslandComment::find(1));
+        $this->assertSame('test_comment2', IslandComment::find(2)->comment);
+        $this->assertSame('test_comment2', json_decode($response->content())->comment);
+    }
+
+    public function testPostMaxChars()
+    {
+        $user = User::factory()->create();
+        $island = Island::factory()->setUser($user)->create();
+
+        $response = $this->actingAs($user)
+            ->post('/api/islands/' . $island->id . '/comments', [
+                'comment' => str_repeat('あ', 129),
+            ]);
+
+        $response->assertStatus(400);
+        $this->assertNull(IslandComment::find(1));
+
+        $response = $this->actingAs($user)
+            ->post('/api/islands/' . $island->id . '/comments', [
+                'comment' => str_repeat('あ', 128),
+            ]);
+
+        $response->assertOk();
+    }
+
+    public function testPostNotRegistered()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->post('/api/islands/' . 1 . '/comments', [
+                'comment' => 'test_comment',
+            ]);
+
+        $response->assertStatus(403);
+        $this->assertNull(IslandComment::find(1));
+    }
+
+    public function testPostTryOthersIsland()
+    {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+        $island = Island::factory()->setUser($user2)->create();
+
+        $response = $this->actingAs($user1)
+            ->post('/api/islands/' . $island->id . '/comments', [
+                'comment' => 'test_comment',
+            ]);
+
+        $response->assertStatus(403);
+        $this->assertNull(IslandComment::find(1));
+    }
+
+}

--- a/app/tests/App/Http/Controllers/Web/Register/IndexControllerTest.php
+++ b/app/tests/App/Http/Controllers/Web/Register/IndexControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\App\Http\Controllers\Register;
+namespace Tests\App\Http\Controllers\Web\Register;
 
 use App\Models\Island;
 use App\Models\IslandPlan;


### PR DESCRIPTION
## 概要

- オーナーコメントを保存するDBテーブルを追加しました
- コメントの編集APIを追加しました
    - エンドポイントは `POST /islands/{island_id}/comments` です
- 島の情報と併せてcommentsを返すようにしました
    - トップページ、島詳細画面（`/islands/{island_id}`）、島編集画面（`/islands/{island_id}/plans`）です