### PR TITLE
IDE補完の改善

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,6 @@ seeding-testing:
 ide-helper-generate:
 	docker compose exec --user debian app sudo php artisan ide-helper:generate
 	docker compose exec --user debian app sudo php artisan ide-helper:model --write-mixin
-	docker compose exec --user debian app sudo php artisan ide-helper:meta
 create-log-file:
 	docker compose exec --user debian app sudo chown www-data:www-data /app/storage/ -R
 	docker compose exec --user debian app sudo chmod 777 /app/storage/ -R

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ seeding-testing:
 	docker compose exec --user www-data app php artisan db:seed --env=testing
 ide-helper-generate:
 	docker compose exec --user debian app sudo php artisan ide-helper:generate
-	docker compose exec --user debian app sudo php artisan ide-helper:model --nowrite
+	docker compose exec --user debian app sudo php artisan ide-helper:model --write-mixin
+	docker compose exec --user debian app sudo php artisan ide-helper:meta
 create-log-file:
 	docker compose exec --user debian app sudo chown www-data:www-data /app/storage/ -R
 	docker compose exec --user debian app sudo chmod 777 /app/storage/ -R

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -18,3 +18,4 @@ yarn-error.log
 /.vscode
 _ide_helper.php
 _ide_helper_models.php
+.phpstorm.meta.php

--- a/app/app/Models/Island.php
+++ b/app/app/Models/Island.php
@@ -5,6 +5,9 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @mixin IdeHelperIsland
+ */
 class Island extends Model
 {
     use HasFactory;

--- a/app/app/Models/IslandBbs.php
+++ b/app/app/Models/IslandBbs.php
@@ -5,6 +5,9 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @mixin IdeHelperIslandBbs
+ */
 class IslandBbs extends Model
 {
     use HasFactory;

--- a/app/app/Models/IslandComment.php
+++ b/app/app/Models/IslandComment.php
@@ -6,6 +6,9 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
+/**
+ * @mixin IdeHelperIslandComment
+ */
 class IslandComment extends Model
 {
     use SoftDeletes;

--- a/app/app/Models/IslandHistory.php
+++ b/app/app/Models/IslandHistory.php
@@ -5,6 +5,9 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @mixin IdeHelperIslandHistory
+ */
 class IslandHistory extends Model
 {
     use HasFactory;

--- a/app/app/Models/IslandLog.php
+++ b/app/app/Models/IslandLog.php
@@ -5,6 +5,9 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @mixin IdeHelperIslandLog
+ */
 class IslandLog extends Model
 {
     use HasFactory;

--- a/app/app/Models/IslandPlan.php
+++ b/app/app/Models/IslandPlan.php
@@ -6,6 +6,9 @@ use App\Entity\Plan\Plans;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @mixin IdeHelperIslandPlan
+ */
 class IslandPlan extends Model
 {
     use HasFactory;

--- a/app/app/Models/IslandStatus.php
+++ b/app/app/Models/IslandStatus.php
@@ -6,6 +6,9 @@ use App\Entity\Status\Status;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @mixin IdeHelperIslandStatus
+ */
 class IslandStatus extends Model
 {
     use HasFactory;

--- a/app/app/Models/IslandTerrain.php
+++ b/app/app/Models/IslandTerrain.php
@@ -6,6 +6,9 @@ use App\Entity\Terrain\Terrain;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @mixin IdeHelperIslandTerrain
+ */
 class IslandTerrain extends Model
 {
     use HasFactory;

--- a/app/app/Models/Turn.php
+++ b/app/app/Models/Turn.php
@@ -5,6 +5,9 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @mixin IdeHelperTurn
+ */
 class Turn extends Model
 {
     use HasFactory;

--- a/app/app/Models/User.php
+++ b/app/app/Models/User.php
@@ -8,6 +8,9 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 
+/**
+ * @mixin IdeHelperUser
+ */
 class User extends Authenticatable
 {
     use HasApiTokens, HasFactory, Notifiable;

--- a/app/app/Models/UserAuthentication.php
+++ b/app/app/Models/UserAuthentication.php
@@ -5,6 +5,9 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @mixin IdeHelperUserAuthentication
+ */
 class UserAuthentication extends Model
 {
     use HasFactory;


### PR DESCRIPTION
# Overview

IDEの補完周りを改善しました。
Modelのphpに修正が加わるため、最終的に導入するかどうかは任せます。

# Description

## PHPStormでの補完の改善

Makefileに `php artisan ide-helper:meta` を追加しました。合わせて生成される `.phpstorm.meta.php` をgitignoreしています。
これにより`\App::('HakoniwaService')->`なども続きが補完できるようになります。
Dispatcher methodsなどの補完が効くようになります。詳しくは以下のページを参照してください。
![スクリーンショット 2023-05-22 115528](https://github.com/mjtakenon/hakoniwa/assets/130939038/e2d14975-ab76-4db3-9957-f691b66d9351)

## ide-helper:modelのオプション変更

ide-helper:modelの生成時オプションを `--no-write` から `--write-mixin` に変更しました。
Multiple Definitionsのエラーがなくなります。

### --no-writeを使うことによる弊害

普通ide-helperでは直接対象のモデルに型の情報がphpdocで書き込まれますが、
これを行うと非常にコードが増えてしまい、コンフリクトの危険性が高まります。
そのため`--no-write` オプションを使うと分離できますが、この場合同じクラス定義が複数されることになりIDEが読みに行こうとした時に **Multiple definitions exist for class** のエラーが出ます。
![スクリーンショット 2023-05-22 104818](https://github.com/mjtakenon/hakoniwa/assets/130939038/86413fa5-1060-4d48-bbc2-a28b7bf02109)

それと同時に、元クラスを参照しようとしたときに毎回選択が挟まってしまい非効率的です。
![スクリーンショット 2023-05-22 104832](https://github.com/mjtakenon/hakoniwa/assets/130939038/baaf72fa-cd8e-4ed3-aca7-c6703c9b2a68)

Githubのissueなども眺めていたところ気づいたのですが、どうやら `--no-write` オプションを使ったときに生成された_ide_helper_models.phpをそのままにしておくのは作者としても非推奨の使い方のようで、生成されたファイルの先頭に「**モデルにphpDocsをコピーして、二重定義を回避するためにこのファイルを削除してください**」という注意書きが記載されています。
![スクリーンショット 2023-05-22 104737](https://github.com/mjtakenon/hakoniwa/assets/130939038/f5fe8e44-8bd3-45a0-b9c3-58cde9cf57d2)

### --write-mixinオプションについて

この二重定義を解決したうえでphpdocsを分離する方法として、`--write-mixin` オプションがあります。
このオプションで生成するとき、まず最初にモデルのクラスの先頭にmixin先を指定したphpdocsが自動で追加されます。
![スクリーンショット 2023-05-22 105624](https://github.com/mjtakenon/hakoniwa/assets/130939038/075da23b-8ed9-438c-b0ae-741ba83611d8)

その上で_ide_helper_models.phpに各モデルについてのphpdocsが生成されます。
![スクリーンショット 2023-05-22 105705](https://github.com/mjtakenon/hakoniwa/assets/130939038/48f76e6d-19b2-4404-b1db-39b9d19d67fc)

Model側にも書き込まれてしまうためそこは難点なのですが、 `@mixin` 節のみが追加されるので大幅にコンフリクトの危険性は下がり、コードが冗長になることを防ぐことができます。

ただしModel自体を書き換えてしまうことは確かなので、導入の是非については判断を委ねます。