### PR TITLE
CSSが読み込まれないバグの修正

### DIFF
--- a/app/resources/js/components/VueHeader.vue
+++ b/app/resources/js/components/VueHeader.vue
@@ -82,7 +82,7 @@ export default defineComponent({
     setup(props) {
         const store = useMainStore();
         const theme = localStorage.getItem('theme');
-        if (theme !== undefined) {
+        if (theme !== null && theme !== undefined) {
             store.theme = JSON.parse(theme);
         }
         if(props.ownedIsland !== null && props.ownedIsland !== undefined) {

--- a/app/resources/js/store/Entity/Theme.ts
+++ b/app/resources/js/store/Entity/Theme.ts
@@ -9,5 +9,5 @@ export interface Theme{
 export const defaultTheme: Theme = {
     name: "light",
     themeClass: "theme-light",
-    type: "dark"
+    type: "light"
 }


### PR DESCRIPTION
# Overview

CSSが読み込まれないバグの修正をしました。

# Description

localStorageの判定がgetItemsしたときにnullが帰ってくるのですが、誤ってundefinedで判定していました。
ブラウザの仕様違いが怖いので、一応undefiendも残してあります。
ついでに間違っていたdefaultThemeも直しておきました。