### PR TITLE
島・オーナー名の重複時バリデーションの追加とエラー表示の修正

### DIFF
--- a/app/app/Http/Controllers/Web/Register/IndexController.php
+++ b/app/app/Http/Controllers/Web/Register/IndexController.php
@@ -43,6 +43,15 @@ class IndexController extends Controller
         $validated = $validator->safe()->collect();
 
         $island = \DB::transaction(function () use ($validated) {
+
+            if (Island::where('name', $validated->get('island_name'))->exists()) {
+                \Redirect::back()->withErrors(['message' => '島名は既に使われています。'])->withInput()->throwResponse();
+            }
+
+            if (Island::where('owner_name', $validated->get('owner_name'))->exists()) {
+                \Redirect::back()->withErrors(['message' => 'オーナー名は既に使われています。'])->withInput()->throwResponse();
+            }
+
             $island = new Island();
             $island->user_id = \Auth::user()->getAuthIdentifier();
             $island->name = $validated->get('island_name');

--- a/app/resources/js/components/IslandNameSettings.vue
+++ b/app/resources/js/components/IslandNameSettings.vue
@@ -104,10 +104,14 @@ export default defineComponent({
                     this.otherError = "名称の変更がなかったため、更新を中止しました。"
                     this.nameError = " ";
                     this.ownerError = " ";
-                }
-                else {
+                } else if (this.store.patchIslandNameError === "island_name_duplicated") {
+                    this.nameError = "島名が既に利用されているため、変更できません。"
+                } else if (this.store.patchIslandNameError === "owner_name_duplicated") {
+                    this.ownerError = "オーナー名が既に利用されているため、変更できません。"
+                } else {
                     this.otherError = "不明なエラーが発生しました。"
                 }
+                console.log(this.store.patchIslandNameError)
             }
         },
         checkInputs() {

--- a/app/resources/views/pages/register.blade.php
+++ b/app/resources/views/pages/register.blade.php
@@ -49,7 +49,7 @@
                 </div>
             </div>
 
-            @error('')
+            @error('message')
                 <div class="text-error text-center mb-4 font-bold">{{$message}}</div>
             @enderror
 

--- a/app/resources/views/pages/register.blade.php
+++ b/app/resources/views/pages/register.blade.php
@@ -12,7 +12,18 @@
                         <span>🏝</span>
                         <span>島</span>
                     </div>
-                    <input id="island-name-input" class="input-with-icon" type="text" name="island_name" placeholder="島名を入力してください" maxlength="32" minlength="1" required pattern=".*\S+.*">
+                    <input
+                        id="island-name-input"
+                        class="input-with-icon"
+                        type="text"
+                        name="island_name"
+                        placeholder="島名を入力してください"
+                        maxlength="32"
+                        minlength="1"
+                        required
+                        pattern=".*\S+.*"
+                        value="{{old('island_name')}}"
+                    >
 
                 </div>
 {{--                <p class="help is-success">この島名は利用可能です！</p>--}}
@@ -22,10 +33,25 @@
             <div class="field">
                 <label class="label">あなたのお名前は?（最大32文字）</label>
                 <div class="control has-icons-left has-icons-right">
-                    <input id="owner-name-input" class="input" type="text" name="owner_name" placeholder="お名前を入力してください" maxlength="32" minlength="1" required pattern=".*\S+.*">
+                    <input
+                        id="owner-name-input"
+                        class="input"
+                        type="text"
+                        name="owner_name"
+                        placeholder="お名前を入力してください"
+                        maxlength="32"
+                        minlength="1"
+                        required
+                        pattern=".*\S+.*"
+                        value="{{old('owner_name')}}"
+                    >
                     <span class="icon is-small is-left"></span>
                 </div>
             </div>
+
+            @error('')
+                <div class="text-error text-center mb-4 font-bold">{{$message}}</div>
+            @enderror
 
             <div class="field">
                 <div class="control">


### PR DESCRIPTION
## 概要

島の登録時と、情報変更時に島名・オーナー名で重複していた場合、今までは500サーバーエラーを返していました。
登録時はエラーメッセージと共に登録画面にリダイレクトし、変更時は400 bad requestとエラーレスポンスコードを返すよう修正しました。