### PR TITLE
島名の設定画面で末尾に「島」を表示

### DIFF
--- a/app/resources/js/components/IslandNameSettings.vue
+++ b/app/resources/js/components/IslandNameSettings.vue
@@ -14,11 +14,16 @@
                 <span>島の名前（最大32文字）</span>
                 <span v-if="nameError !== ''" class="input-error">{{ nameError }}</span>
             </div>
-            <input type="text" name="island-name" maxlength="32" minlength="1"
-                   v-model="name" @blur="checkInputs"
-                   :disabled="isSubmitting || !isFundsEnough"
-                   class="input-form" :class="{'error': nameError !== ''}"
-            >
+            <div class="relative w-full mb-2">
+                <div class="icons">
+                    <span>島</span>
+                </div>
+                <input type="text" name="island-name" maxlength="32" minlength="1"
+                       v-model="name" @blur="checkInputs"
+                       :disabled="isSubmitting || !isFundsEnough"
+                       class="input-form" :class="{'error': nameError !== ''}"
+                >
+            </div>
         </div>
         <div class="input-wrapper">
             <div class="input-header">
@@ -165,6 +170,10 @@ export default defineComponent({
         @apply mt-8;
     }
 
+    .icons {
+        @apply absolute flex items-center justify-end w-full py-1 pr-3 z-10 pointer-events-none;
+    }
+
     .input-wrapper {
         @apply mt-2　text-on-surface-variant;
 
@@ -180,7 +189,7 @@ export default defineComponent({
             @apply w-full bg-background text-on-background p-1 outline-1 outline-primary rounded drop-shadow-md;
             @apply disabled:opacity-40;
             // sp
-            @apply w-full mb-2 px-2;
+            @apply w-full px-2;
             // desktop
             @apply md:px-4;
 


### PR DESCRIPTION
# Overview

`/settings` 画面を作った際、島の名前設定の末尾に「島」が表示されていませんでした。
`/register` ページと同様に末尾に「島」を表示するようにしました。

![image](https://github.com/mjtakenon/hakoniwa/assets/130939038/5cacde58-5104-40b4-adf3-b4b063ef8b75)
