### PR TITLE
フロントのデザインを複数個所修正

### DIFF
--- a/app/resources/css/app.scss
+++ b/app/resources/css/app.scss
@@ -7,6 +7,20 @@
 @layer base {
     body {
         @apply bg-background text-on-background break-words;
+
+        ::-webkit-scrollbar {
+            width: 0.5rem;
+        }
+
+        ::-webkit-scrollbar-track {
+            background: var(--theme-background);
+            border-radius: 7px;
+        }
+
+        ::-webkit-scrollbar-thumb {
+            background: var(--theme-on-background);
+            border-radius: 7px;
+        }
     }
 
     p {

--- a/app/resources/css/app.scss
+++ b/app/resources/css/app.scss
@@ -106,7 +106,7 @@
 }
 
 #app {
-    @apply bg-background text-on-background pb-10;
+    @apply bg-background text-on-background pb-0;
 }
 
 #index {

--- a/app/resources/css/app.scss
+++ b/app/resources/css/app.scss
@@ -13,12 +13,12 @@
         }
 
         ::-webkit-scrollbar-track {
-            background: var(--theme-background);
+            background: var(--theme-scroll-track);
             border-radius: 7px;
         }
 
         ::-webkit-scrollbar-thumb {
-            background: var(--theme-on-background);
+            background: var(--theme-scroll-thumb);
             border-radius: 7px;
         }
     }

--- a/app/resources/css/themes.scss
+++ b/app/resources/css/themes.scss
@@ -58,7 +58,7 @@
     --theme-on-surface: #1a1c1e;
 
     // Scroll bar
-    --theme-scroll-thumb: #969696;
+    --theme-scroll-thumb: #ffffff;
     --theme-scroll-track: #232E3380;
 
     // Others

--- a/app/resources/css/themes.scss
+++ b/app/resources/css/themes.scss
@@ -57,7 +57,11 @@
     --theme-surface: #ffffff;
     --theme-on-surface: #1a1c1e;
 
-    // Texts
+    // Scroll bar
+    --theme-scroll-thumb: #969696;
+    --theme-scroll-track: #232E3380;
+
+    // Others
     --theme-on-link: #485fc7;
     --theme-outline: #72777f;
     --theme-surface-variant: #dee3eb;
@@ -100,6 +104,10 @@
     --theme-on-background: #e2e2e5;
     --theme-surface: #34373b;
     --theme-on-surface: #e2e2e5;
+
+    // Scroll bar
+    --theme-scroll-thumb: #969696;
+    --theme-scroll-track: #232E3380;
 
     // Others
     --theme-on-link: #acb7e7;

--- a/app/resources/js/components/IslandEditor.vue
+++ b/app/resources/js/components/IslandEditor.vue
@@ -226,7 +226,7 @@ export default defineComponent({
         },
         onWindowSizeChanged() {
             const newScreenWidth = document.documentElement.clientWidth;
-            if (this.screenWidth != newScreenWidth) {
+            if (this.screenWidth !== newScreenWidth) {
                 this.screenWidth = newScreenWidth;
                 this.showHoverWindow = false;
                 this.showPlanWindow = false;

--- a/app/resources/js/components/PlanController.vue
+++ b/app/resources/js/components/PlanController.vue
@@ -299,7 +299,11 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 #plan-controller {
-    @apply w-[45%] bg-surface-variant text-on-surface-variant rounded-xl mx-1 lg:mr-2 mb-3 p-1 max-lg:h-fit lg:p-2 md:max-w-[200px] lg:max-w-[230px] drop-shadow-md;
+    @apply bg-surface-variant text-on-surface-variant rounded-xl mx-1 lg:mr-2 mb-3 p-1 max-lg:h-fit lg:p-2 md:max-w-[200px] lg:max-w-[230px] drop-shadow-md;
+
+    &.order-2 {
+        @apply w-[45%] max-w-full;
+    }
 
     .section-header {
         @apply w-full text-left pl-2 text-on-surface-variant border-on-surface-variant border-b mb-2 text-sm;

--- a/app/resources/js/components/PlanController.vue
+++ b/app/resources/js/components/PlanController.vue
@@ -299,7 +299,7 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 #plan-controller {
-    @apply w-[45%] bg-surface-variant text-on-surface-variant rounded-xl mx-1 lg:mr-2 mb-3 p-1 max-lg:h-fit lg:p-2 max-w-[230px] drop-shadow-md;
+    @apply w-[45%] bg-surface-variant text-on-surface-variant rounded-xl mx-1 lg:mr-2 mb-3 p-1 max-lg:h-fit lg:p-2 md:max-w-[200px] lg:max-w-[230px] drop-shadow-md;
 
     .section-header {
         @apply w-full text-left pl-2 text-on-surface-variant border-on-surface-variant border-b mb-2 text-sm;

--- a/app/resources/js/components/PlanList.vue
+++ b/app/resources/js/components/PlanList.vue
@@ -78,7 +78,13 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 #plan-list {
-    @apply rounded-xl mx-1 lg:ml-3 mb-3 p-2 w-[45%] max-w-[200px] lg:max-w-[230px] md:max-h-[496px] text-left overflow-x-visible overflow-y-scroll drop-shadow-md;
+    @apply rounded-xl mx-1 lg:ml-3 mb-3 p-2 max-w-[200px] lg:max-w-[230px] md:max-h-[496px] text-left overflow-x-visible overflow-y-hidden drop-shadow-md;
+    // 2-column
+    &.order-2 {
+        @apply w-[45%] max-w-full max-h-[65vh];
+    }
+
+    // 3-column
 
     .send-status {
         @apply w-full text-center text-white mb-2;
@@ -89,7 +95,7 @@ export default defineComponent({
     }
 
     .plans {
-        @apply text-sm w-full;
+        @apply text-sm w-full h-[90%] overflow-y-scroll;
 
         .plan {
             @apply w-full flex ;

--- a/app/resources/js/components/PlanList.vue
+++ b/app/resources/js/components/PlanList.vue
@@ -78,7 +78,7 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 #plan-list {
-    @apply rounded-xl mx-1 lg:ml-3 mb-3 p-2 w-[45%] max-w-[230px] lg:max-h-[496px] text-left overflow-x-visible overflow-y-scroll drop-shadow-md;
+    @apply rounded-xl mx-1 lg:ml-3 mb-3 p-2 w-[45%] max-w-[200px] lg:max-w-[230px] md:max-h-[496px] text-left overflow-x-visible overflow-y-scroll drop-shadow-md;
 
     .send-status {
         @apply w-full text-center text-white mb-2;
@@ -92,7 +92,7 @@ export default defineComponent({
         @apply text-sm w-full;
 
         .plan {
-            @apply w-full flex;
+            @apply w-full flex ;
 
             .plan-index {
                 @apply min-w-[1rem] mr-0.5;

--- a/app/resources/js/components/VueHeader.vue
+++ b/app/resources/js/components/VueHeader.vue
@@ -12,6 +12,8 @@
             <img class="hamburger-icon" src="/img/hakoniwa/ui/hamburger.svg">
         </button>
 
+
+
         <div class="hamburger-elements"
              :class="[isOpenHamburgerMenu ? 'max-md:max-h-52' : 'max-md:max-h-0']">
             <div v-if="isLoggedIn" class="navbar-menu">
@@ -20,32 +22,29 @@
                 </div>
                 <a v-if="isIslandRegistered" class="menu-item primary group" :href="'/islands/'+store.user.id+'/plans'"
                    title="開発画面に行く">
-                    <svg class="menu-icon fill-on-primary group-hover:fill-primary" xmlns="http://www.w3.org/2000/svg"
-                         viewBox="0 96 960 960">
-                        <path
-                            d="M180 976q-24 0-42-18t-18-42V296q0-24 18-42t42-18h65v-60h65v60h340v-60h65v60h65q24 0 42 18t18 42v301h-60V486H180v430h319v60H180Zm709-219-71-71 29-29q8-8 21-8t21 8l29 29q8 8 8 21t-8 21l-29 29Zm-330 259v-71l216-216 71 71-216 216h-71Z"/>
-                    </svg>
-                    <span class="menu-title text-on-primary group-hover:text-primary">開発画面に行く</span>
+                    <font-awesome-icon
+                        icon="fa-solid fa-pen-to-square"
+                        class="menu-icon text-on-primary group-hover:text-primary"
+                    ></font-awesome-icon>
+                    <span class="menu-title plan-title text-on-primary group-hover:text-primary">島を開発</span>
                 </a>
                 <a v-if="isIslandRegistered" class="menu-item group" href="/settings" title="設定">
-                    <svg class="menu-icon fill-on-surface-variant group-hover:fill-surface-variant"
-                         xmlns="http://www.w3.org/2000/svg" viewBox="0 96 960 960">
-                        <path
-                            d="m388 976-20-126q-19-7-40-19t-37-25l-118 54-93-164 108-79q-2-9-2.5-20.5T185 576q0-9 .5-20.5T188 535L80 456l93-164 118 54q16-13 37-25t40-18l20-127h184l20 126q19 7 40.5 18.5T669 346l118-54 93 164-108 77q2 10 2.5 21.5t.5 21.5q0 10-.5 21t-2.5 21l108 78-93 164-118-54q-16 13-36.5 25.5T592 850l-20 126H388Zm92-270q54 0 92-38t38-92q0-54-38-92t-92-38q-54 0-92 38t-38 92q0 54 38 92t92 38Z"/>
-                    </svg>
+                    <font-awesome-icon
+                        icon="fa-solid fa-gear"
+                        class="menu-icon text-on-surface-variant group-hover:text-surface-variant"
+                    ></font-awesome-icon>
                     <span class="menu-title text-on-surface-variant group-hover:text-surface-variant">設定</span>
                 </a>
                 <a v-if="!isIslandRegistered" class=" button-primary navbar-register" href="/register">
                     島を探しに行く（新規登録）
                 </a>
-                <form class="menu-item group" method="POST" name="logout" action="/logout">
+                <form method="POST" name="logout" action="/logout">
                     <input type="hidden" name="_token" :value="csrfToken">
-                    <a href="javascript:logout.submit()" title="ログアウト">
-                        <svg class="menu-icon fill-on-surface-variant group-hover:fill-surface-variant"
-                             xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960">
-                            <path
-                                d="M180-120q-24 0-42-18t-18-42v-600q0-24 18-42t42-18h291v60H180v600h291v60H180Zm486-185-43-43 102-102H375v-60h348L621-612l43-43 176 176-174 174Z"/>
-                        </svg>
+                    <a href="javascript:logout.submit()"  class="menu-item group" title="ログアウト">
+                        <font-awesome-icon
+                            icon="fa-solid fa-arrow-right-from-bracket"
+                            class="menu-icon text-on-surface-variant group-hover:text-surface-variant"
+                        ></font-awesome-icon>
                         <span class="menu-title text-on-surface-variant group-hover:text-surface-variant">ログアウト</span>
                     </a>
                 </form>
@@ -71,6 +70,10 @@
 import {defineComponent} from "vue";
 import ThemeSwitcher from "./ThemeSwitcher.vue";
 import {useMainStore} from "../store/MainStore";
+import {library} from "@fortawesome/fontawesome-svg-core";
+import {faPenToSquare} from "@fortawesome/free-solid-svg-icons";
+import {faGear} from "@fortawesome/free-solid-svg-icons";
+import {faArrowRightFromBracket} from "@fortawesome/free-solid-svg-icons";
 
 export default defineComponent({
     components: {ThemeSwitcher},
@@ -80,6 +83,8 @@ export default defineComponent({
         }
     },
     setup(props) {
+        library.add(faPenToSquare, faGear, faArrowRightFromBracket);
+
         const store = useMainStore();
         const theme = localStorage.getItem('theme');
         if (theme !== null && theme !== undefined) {
@@ -164,14 +169,14 @@ export default defineComponent({
             // sp
             @apply flex items-center px-8 py-2 max-md:mb-1;
             // desktop
-            @apply md:mx-1 md:p-1.5 md:rounded-full bg-surface-variant;
+            @apply md:mx-1 md:p-2 md:rounded-full bg-surface-variant;
 
             &.primary {
                 @apply bg-primary hover:bg-primary-container;
             }
 
             .menu-icon {
-                @apply inline w-6 h-6;
+                @apply inline w-5 h-5 max-w-[1.25rem] max-h-[1.25rem];
                 // sp
                 @apply max-md:mr-5;
             }
@@ -181,6 +186,10 @@ export default defineComponent({
                 @apply font-bold;
                 // desktop
                 @apply md:hidden;
+
+                &.plan-title {
+                    @apply md:ml-2 md:mr-1 md:inline;
+                }
             }
         }
 

--- a/app/resources/js/pages/PlanPage.vue
+++ b/app/resources/js/pages/PlanPage.vue
@@ -4,11 +4,20 @@
         <div class="link-text mb-5"><a href="/">トップへ戻る</a></div>
         <status-table></status-table>
         <div class="flex flex-wrap items-stretch mx-auto justify-center">
-            <plan-controller class="max-md:order-2 grow min-w-0"></plan-controller>
-            <div class="max-md:order-1 max-md:w-full z-30">
+            <plan-controller
+                class="grow"
+                :class="{'order-2' : !canSideBySide}"
+            ></plan-controller>
+            <div
+                class="z-30"
+                :class="{'w-full order-1': !canSideBySide}"
+            >
                 <island-editor></island-editor>
             </div>
-            <plan-list class="max-md:order-2 grow min-w-0"></plan-list>
+            <plan-list
+                class="grow"
+                :class="{'order-2' : !canSideBySide}"
+            ></plan-list>
         </div>
         <comment-form></comment-form>
         <log-viewer
@@ -58,6 +67,7 @@ export default defineComponent({
             },
             hoverWindowTop: 170,
             hoverWindowLeft: 0,
+            screenWidth: document.documentElement.clientWidth,
         }
     },
     setup(props) {
@@ -96,6 +106,25 @@ export default defineComponent({
             turn: turn
         });
         return {store}
+    },
+    computed: {
+        canSideBySide() {
+            return this.screenWidth > 912;
+        }
+    },
+    mounted() {
+        window.addEventListener("resize", this.onWindowSizeChanged);
+    },
+    unmounted() {
+        window.removeEventListener("resize", this.onWindowSizeChanged);
+    },
+    methods: {
+        onWindowSizeChanged() {
+            const newScreenWidth = document.documentElement.clientWidth;
+            if (this.screenWidth !== newScreenWidth) {
+                this.screenWidth = newScreenWidth;
+            }
+        },
     },
     props: {
         hakoniwa: {

--- a/app/resources/js/pages/PlanPage.vue
+++ b/app/resources/js/pages/PlanPage.vue
@@ -4,11 +4,11 @@
         <div class="link-text mb-5"><a href="/">トップへ戻る</a></div>
         <status-table></status-table>
         <div class="flex flex-wrap items-stretch mx-auto justify-center">
-            <plan-controller class="max-lg:order-2 grow"></plan-controller>
-            <div class="max-lg:order-1 max-lg:w-full z-30">
+            <plan-controller class="max-md:order-2 grow min-w-0"></plan-controller>
+            <div class="max-md:order-1 max-md:w-full z-30">
                 <island-editor></island-editor>
             </div>
-            <plan-list class="max-lg:order-2 grow"></plan-list>
+            <plan-list class="max-md:order-2 grow min-w-0"></plan-list>
         </div>
         <comment-form></comment-form>
         <log-viewer


### PR DESCRIPTION
# Overview

フロントのデザインを複数個所修正しました。

# Description

## フッターの下にあった不要な余白の削除

元々ログ表示が画面下に張り付かないように `#app` に対してborder-bottomを付けていたのですが、フッターの下に余白が発生していたので修正しました。

## ヘッダーの修正

ヘッダーのアイコンをFontAwesomeに変更しました。直書きのSVGは削除済みです。
変更に伴い、少しCSSにも修正が入っています。

また以前話題に出ていた島編集ボタンをわかりやすくするための文字を表示しました。
当初の想定では「自分の島へ」という文言を使う予定でしたが、いざ置いてみると自分の島で何があるのか？というのがプレイ済みでないと意図を汲み取れないので「島を開発」というタイトルにしました。気に入らなかったら修正してください。

![image](https://github.com/mjtakenon/hakoniwa/assets/130939038/9f066d9a-1bcd-43e8-b05c-d473b92eb823)

## 島編集画面のレイアウト調整

FullHDの半分の画面の時、2段構成になってしまうのが気に入らなかったので直しました。
`PlanController` と `PlanList` を縮めましたが、さほど問題にはならないと思います。

- **before**
![スクリーンショット 2023-05-27 143837](https://github.com/mjtakenon/hakoniwa/assets/130939038/b4cea43a-d4af-41d6-beef-5d63a5e7bee2)


- **after**
![image](https://github.com/mjtakenon/hakoniwa/assets/130939038/c2ac365d-8bc8-407f-b92f-9f0108fdfc14)

## スクロールバーのデザイン変更

bodyの子要素以下のスクロールバーのデザインを変更しました。
Firefoxのスクロールバーは変更していないのですが、FirefoxはChromeと違い初期状態でいい感じのデザインになっていたので特に変えないつもりです。
PlanListのスクロールについてもDOM要素のスクロールを当てる箇所を見直してきれいになりました。
![image](https://github.com/mjtakenon/hakoniwa/assets/130939038/0a959c9c-4a66-4854-98e6-19fb8c8d7234)
