### PR TITLE
IslandEditorのgetIslandTerrainをfilterでなくarrayで返すよう修正

### DIFF
--- a/app/resources/js/components/IslandEditor.vue
+++ b/app/resources/js/components/IslandEditor.vue
@@ -110,11 +110,22 @@ export default defineComponent({
             planWindowY: 0,
             planWindowX: 0,
             isMobile: (document.documentElement.clientWidth < 1024),
+            terrains: [],
         }
     },
     setup() {
         const store = useMainStore();
         return { store };
+    },
+    beforeMount() {
+        this.terrains = new Array(this.store.hakoniwa.height);
+        for (let y = 0; y < this.terrains.length; y++) {
+            this.terrains[y] = new Array(this.store.hakoniwa.width);
+        }
+
+        for(let terrain of this.store.terrains) {
+            this.terrains[terrain.data.point.y][terrain.data.point.x] = terrain;
+        }
     },
     mounted() {
         window.addEventListener("resize", this.onWindowSizeChanged);
@@ -124,9 +135,7 @@ export default defineComponent({
     },
     methods: {
         getIslandTerrain(x, y): Terrain {
-            return this.store.terrains.filter(function (item, idx) {
-                if (item.data.point.x === x && item.data.point.y === y) return true;
-            }).pop();
+            return this.terrains[y][x];
         },
         onMouseOverCell(x, y, event: MouseEvent) {
             const offsetY = 25;


### PR DESCRIPTION
## 概要

島編集画面の処理を修正し、スクリプト実行パフォーマンスを改善しました。

## 詳細

島編集画面について、指定タイルの地形情報を取得する`getIslandTerrain`関数は、Arrayのfilterを使って実装していました。
filterの計算量はO(n)であり、それをv-forで描画している各タイルに対して行っているため、何かしらアクションを起こした場合の計算量がO(n^2)となっており、処理が低速な状態でした。

store.terrainsのデータは現在readonlyであり、更新はしない（これからする予定もない）想定なので、`IslandEditor.vue`にterrainsをローカル変数という形で二次元配列にキャッシュしました。これにより、`getIslandTerrain`はO(1)で実行できるため、以前と比べて高速になったと思います。

## 参考

chromeのパフォーマンス測定機能を利用し、同じ操作を行いパフォーマンスを測定しました。
スクリプト実行にかかる時間が2810ms→617msと、大幅に改善していることがわかります。

修正前パフォーマンス測定結果（sta環境で測定）
<img width="1289" alt="スクリーンショット 2023-06-03 2 05 40" src="https://github.com/mjtakenon/hakoniwa/assets/10828710/f23d0cc5-5c88-49ef-8b4f-e39f5be17e31">

修正後パフォーマンス測定結果（local環境で測定）
<img width="1289" alt="スクリーンショット 2023-06-03 2 05 30" src="https://github.com/mjtakenon/hakoniwa/assets/10828710/bf450b57-02a0-40cb-8e47-087586398b94">
