### PR TITLE
iOSで島編集メニューが重い問題の解決

### DIFF
--- a/app/resources/js/components/StatusTable.vue
+++ b/app/resources/js/components/StatusTable.vue
@@ -12,12 +12,13 @@
             <div class="stats-box-data">
                 <div
                     class="stats-box-num-wrapper"
+                    :id="'data-num-' + index"
                 >
                     <div
                         class="stats-box-data-num"
                         :style="this.isMobile ?
-                            {fontSize: 'clamp(1px, calc(100cqi/' + (status.numText.length*0.5) +'), 1.05rem)'} :
-                            {fontSize: 'clamp(1px, calc(100cqi/' + (status.numText.length*0.5) +'), 1.2rem)'}
+                            {fontSize: 'clamp(1px,'+ status.fontSize +'px,1.05rem)'} :
+                            {fontSize: 'clamp(1px,'+ status.fontSize +'px,1.2rem)'}
                         "
                     >
                         {{ status.numText }}
@@ -60,6 +61,7 @@ export default defineComponent({
                 title: string,
                 numText: string,
                 unit: string,
+                fontSize: number,
             }[],
             isMobile: (document.documentElement.clientWidth < 1024),
             screenWidth: document.documentElement.clientWidth
@@ -76,53 +78,68 @@ export default defineComponent({
                 title: "発展ポイント",
                 numText: this.store.status.development_points.toLocaleString(),
                 unit: "pts",
+                fontSize: 1
             },
             {
                 title: "人口",
                 numText: this.store.status.population.toLocaleString(),
-                unit: "人"
+                unit: "人",
+                fontSize: 1
             },
             {
                 title: "資金",
                 numText: this.store.status.funds.toLocaleString(),
-                unit: "億円"
+                unit: "億円",
+                fontSize: 1
             },
             {
                 title: "食料",
                 numText: this.store.status.foods.toLocaleString(),
-                unit: "㌧"
+                unit: "㌧",
+                fontSize: 1
             },
             {
                 title: "資源",
                 numText: this.store.status.resources.toLocaleString(),
-                unit: "㌧"
+                unit: "㌧",
+                fontSize: 1
             },
             {
                 title: "環境",
                 numText: this.store.getEnvironmentString,
-                unit: ""
+                unit: "",
+                fontSize: 1
             },
             {
                 title: "面積",
                 numText: this.store.status.area.toLocaleString(),
-                unit: "万坪"
+                unit: "万坪",
+                fontSize: 1
             },
             {
                 title: "農業",
                 numText: this.store.status.foods_production_capacity.toLocaleString(),
-                unit: "人規模"
+                unit: "人規模",
+                fontSize: 1
             },
             {
                 title: "工業",
                 numText: this.store.status.funds_production_capacity.toLocaleString(),
-                unit: "人規模"
+                unit: "人規模",
+                fontSize: 1
             },
             {
                 title: "資源生産",
-                numText: this.store.status.resources_production_capacity.toLocaleString(),
-                unit: "人規模"
+                numText: (9007199254740991).toLocaleString(),
+                //numText: this.store.status.resources_production_capacity.toLocaleString(),
+                unit: "人規模",
+                fontSize: 1
             },
         ]
+
+        this.$nextTick(() => {
+            this.calcNumFontSizes();
+        })
     },
     unmounted() {
         window.removeEventListener("resize", this.onWindowSizeChanged);
@@ -137,13 +154,25 @@ export default defineComponent({
             } else {
                 return this.store.island.comment;
             }
-        }
+        },
     },
     methods: {
+        calcNumFontSizes() {
+            this.statuses.forEach((stat, index) => {
+                const w = document.getElementById("data-num-" + index).clientWidth;
+                console.debug(document.getElementById("data-num-" + index));
+                if(this.screenWidth < 768) { // Tailwind md:
+                    stat.fontSize = w / (stat.numText.length*0.7);
+                } else {
+                    stat.fontSize = w / (stat.numText.length*0.5);
+                }
+            })
+        },
         onWindowSizeChanged() {
             const newScreenWidth = document.documentElement.clientWidth;
             if (this.screenWidth != newScreenWidth) {
                 this.isMobile = (document.documentElement.clientWidth < 1024);
+                this.calcNumFontSizes()
             }
         },
     }
@@ -165,7 +194,6 @@ export default defineComponent({
             @apply flex items-end flex-wrap h-8;
 
             .stats-box-num-wrapper {
-                container-type: inline-size;
                 @apply max-lg:w-full lg:grow min-w-0 text-right;
             }
 

--- a/app/resources/js/components/StatusTable.vue
+++ b/app/resources/js/components/StatusTable.vue
@@ -130,8 +130,7 @@ export default defineComponent({
             },
             {
                 title: "資源生産",
-                numText: (9007199254740991).toLocaleString(),
-                //numText: this.store.status.resources_production_capacity.toLocaleString(),
+                numText: this.store.status.resources_production_capacity.toLocaleString(),
                 unit: "人規模",
                 fontSize: 1
             },
@@ -160,11 +159,13 @@ export default defineComponent({
         calcNumFontSizes() {
             this.statuses.forEach((stat, index) => {
                 const w = document.getElementById("data-num-" + index).clientWidth;
-                console.debug(document.getElementById("data-num-" + index));
+                console.debug(w);
                 if(this.screenWidth < 768) { // Tailwind md:
                     stat.fontSize = w / (stat.numText.length*0.7);
-                } else {
+                } else if(this.screenWidth < 1024) {
                     stat.fontSize = w / (stat.numText.length*0.5);
+                } else {
+                    stat.fontSize = 124 / (stat.numText.length*0.5);
                 }
             })
         },


### PR DESCRIPTION
# Overview

iOSで島編集画面のタイルをタップした時に出てくるメニューが非常に重い問題を解決しました。
fixed #129 

# Description

以前にフォントサイズ変更の仕様変更で使用したContainer Queryが原因でした。
そのため直接的な原因は島編集画面ではなく、`StatusTable.vue` のほうでした。

かといって以前の仕様に戻すとまたメモリリークが起きてしまうため、実装をまた大幅に変更しました。
fontSizeを用意しておき、DOM要素がレンダリング後（this.$nextTick）にコンテナのサイズを計算して調整しています。
v-bindからmethodを直接呼び出しているわけではなく、あくまでscreenWidthの変更を検知して再計算が走るので計算コストもそこまで重くないはずです。

ただ実装がレスポンシブベースではあるものの、StatusTableの発展ポイント～資源生産の個所のレイアウトを今後大幅に変更した場合は崩れる可能性があります。

たぶんこれが最適解だと思いますが、もしもっと改善案が浮かんだら再度修正するかもしれません。