### PR TITLE
海賊を倒したとき懸賞金がもらえるよう処理を追加

### DIFF
--- a/app/app/Entity/Cell/Ship/Battleship.php
+++ b/app/app/Entity/Cell/Ship/Battleship.php
@@ -10,6 +10,8 @@ use App\Entity\Cell\PassTurnResult;
 use App\Entity\Event\ForeignIsland\ReturnShipToAffiliationIsland;
 use App\Entity\Log\LogRow\AttackAndDefeatLog;
 use App\Entity\Log\LogRow\AttackLog;
+use App\Entity\Log\LogRow\FindBuriedTreasureLog;
+use App\Entity\Log\LogRow\ReceiveBountyLog;
 use App\Entity\Log\Logs;
 use App\Entity\Status\Status;
 use App\Entity\Terrain\Terrain;
@@ -110,6 +112,14 @@ class Battleship extends CombatantShip implements IHasMaintenanceNumberOfPeople
             $enemyShip->damage = 100;
 
             $logs->add(new AttackAndDefeatLog($island, deep_copy($this), deep_copy($enemyShip), $attackDamage));
+
+            // 海賊の場合懸賞金を受け取る
+            if ($enemyShip::TYPE === Pirate::TYPE) {
+                $amount = random_int(100, 1000);
+                $status->setFunds($status->getFunds() + $amount);
+                $logs->add(new ReceiveBountyLog(deep_copy($enemyShip), $amount));
+            }
+
             if ($enemyShip->getElevation() === CellConst::ELEVATION_SHALLOW) {
                 $terrain->setCell($enemyShip->getPoint(), new Shallow(point: $enemyShip->getPoint()));
             } else {

--- a/app/app/Entity/Log/LogRow/ReceiveBountyLog.php
+++ b/app/app/Entity/Log/LogRow/ReceiveBountyLog.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Entity\Log\LogRow;
+
+use App\Entity\Cell\Cell;
+use App\Entity\Log\LogConst;
+use App\Entity\Log\LogRow;
+use App\Models\Island;
+
+class ReceiveBountyLog extends LogRow
+{
+    private Cell $cell;
+    private int $amount;
+
+    public function __construct(Cell $cell, int $amount)
+    {
+        $this->cell = $cell;
+        $this->amount = $amount;
+    }
+
+    public function generate(): string
+    {
+        return json_encode([
+            ['text' => $this->cell->getName(), 'style' => LogConst::BOLD . LogConst::COLOR_DANGER],
+            ['text' => 'にかけられていた懸賞金'],
+            ['text' => $this->amount . '億円', 'style' => LogConst::BOLD],
+            ['text' => 'を受け取りました。'],
+        ]);
+    }
+
+    public function getVisibility(): string
+    {
+        return LogConst::VISIBILITY_PUBLIC;
+    }
+}

--- a/app/composer.json
+++ b/app/composer.json
@@ -16,7 +16,6 @@
     },
     "require-dev": {
         "barryvdh/laravel-ide-helper": "^2.13",
-        "beyondcode/laravel-er-diagram-generator": "^2.0",
         "doctrine/dbal": "^3.6",
         "fakerphp/faker": "^1.9.1",
         "laravel/pint": "^1.0",

--- a/app/composer.lock
+++ b/app/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c6bd83b4d003b78bf8f38a290bd1d557",
+    "content-hash": "c0562238e1501163bf81c6ef7bc7416b",
     "packages": [
         {
             "name": "brick/math",
@@ -5755,69 +5755,6 @@
             "time": "2022-10-31T15:35:43+00:00"
         },
         {
-            "name": "beyondcode/laravel-er-diagram-generator",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/beyondcode/laravel-er-diagram-generator.git",
-                "reference": "548a1f37ce27137682bf6286f87ad9e74c716659"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/beyondcode/laravel-er-diagram-generator/zipball/548a1f37ce27137682bf6286f87ad9e74c716659",
-                "reference": "548a1f37ce27137682bf6286f87ad9e74c716659",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/dbal": "~2.3|^3.3",
-                "nikic/php-parser": "^2.0|^3.0|^4.0",
-                "php": "^7.1|^8.0",
-                "phpdocumentor/graphviz": "^1.0"
-            },
-            "require-dev": {
-                "larapack/dd": "^1.0",
-                "orchestra/testbench": "~3.5|~3.6|~3.7|~3.8|^4.0|^7.0",
-                "phpunit/phpunit": "^7.0| ^8.0|^9.5.10",
-                "spatie/phpunit-snapshot-assertions": "^1.3|^4.2"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "BeyondCode\\ErdGenerator\\ErdGeneratorServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "BeyondCode\\ErdGenerator\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marcel Pociot",
-                    "email": "marcel@beyondco.de",
-                    "homepage": "https://beyondcode.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Generate ER diagrams from your Laravel models.",
-            "homepage": "https://github.com/beyondcode/laravel-er-diagram-generator",
-            "keywords": [
-                "beyondcode",
-                "laravel-er-diagram-generator"
-            ],
-            "support": {
-                "issues": "https://github.com/beyondcode/laravel-er-diagram-generator/issues",
-                "source": "https://github.com/beyondcode/laravel-er-diagram-generator/tree/2.0.0"
-            },
-            "time": "2023-02-10T09:40:15+00:00"
-        },
-        {
             "name": "composer/class-map-generator",
             "version": "1.0.0",
             "source": {
@@ -6958,51 +6895,6 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
-        },
-        {
-            "name": "phpdocumentor/graphviz",
-            "version": "1.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/GraphViz.git",
-                "reference": "a906a90a9f230535f25ea31caf81b2323956283f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/GraphViz/zipball/a906a90a9f230535f25ea31caf81b2323956283f",
-                "reference": "a906a90a9f230535f25ea31caf81b2323956283f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "phpDocumentor": [
-                        "src/",
-                        "tests/unit"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "mike.vanriel@naenius.com"
-                }
-            ],
-            "support": {
-                "issues": "https://github.com/phpDocumentor/GraphViz/issues",
-                "source": "https://github.com/phpDocumentor/GraphViz/tree/master"
-            },
-            "time": "2016-02-02T13:00:08+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/app/database/seeders/RegisterIslandSeeder.php
+++ b/app/database/seeders/RegisterIslandSeeder.php
@@ -30,8 +30,8 @@ class RegisterIslandSeeder extends Seeder
 
         $island = Island::create([
             'user_id' => $user->id,
-            'name' => 'デバッグ用',
-            'owner_name' => '開発者',
+            'name' => fake()->name,
+            'owner_name' => fake()->name,
         ]);
 
         $turn = Turn::latest()->firstOrFail();

--- a/app/tests/App/Scnario/NextTurn.php
+++ b/app/tests/App/Scnario/NextTurn.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\App\Http\Controllers\Api\Islands;
+
+use App\Models\Island;
+use App\Models\IslandComment;
+use App\Models\User;
+use Tests\TestCase;
+
+class CommentsControllerTest extends TestCase
+{
+    public function testPostSuccess()
+    {
+        $user = User::factory()->create();
+        $island = Island::factory()->setUser($user)->create();
+
+        $response = $this->actingAs($user)
+            ->post('/api/islands/' . $island->id . '/comments', [
+                'comment' => 'test_comment',
+            ]);
+
+        $response->assertOk();
+        $this->assertSame(1, IslandComment::where('island_id', $island->id)->count());
+        $islandComment = IslandComment::where('island_id', $island->id)->first();
+        $this->assertSame($island->id, $islandComment->island_id);
+        $this->assertSame('test_comment', $islandComment->comment);
+        $this->assertSame('test_comment', json_decode($response->content())->comment);
+
+        $response = $this->actingAs($user)
+            ->post('/api/islands/' . $island->id . '/comments', [
+                'comment' => '',
+            ]);
+
+        $response->assertOk();
+        $this->assertSame(1, IslandComment::where('island_id', $island->id)->count());
+        $this->assertNull(IslandComment::find($islandComment->id));
+        $islandComment = IslandComment::where('island_id', $island->id)->first();
+        $this->assertSame($island->id, $islandComment->island_id);
+        $this->assertNull($islandComment->comment);
+        $this->assertNull(json_decode($response->content())->comment);
+    }
+
+    public function testPostMaxChars()
+    {
+        $user = User::factory()->create();
+        $island = Island::factory()->setUser($user)->create();
+
+        $response = $this->actingAs($user)
+            ->post('/api/islands/' . $island->id . '/comments', [
+                'comment' => str_repeat('あ', 129),
+            ]);
+
+        $response->assertStatus(400);
+        $this->assertNull(IslandComment::find(1));
+
+        $response = $this->actingAs($user)
+            ->post('/api/islands/' . $island->id . '/comments', [
+                'comment' => str_repeat('あ', 128),
+            ]);
+
+        $response->assertOk();
+    }
+
+    public function testPostNotRegistered()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->post('/api/islands/' . 1 . '/comments', [
+                'comment' => 'test_comment',
+            ]);
+
+        $response->assertForbidden();
+        $this->assertNull(IslandComment::find(1));
+    }
+
+    public function testPostTryOthersIsland()
+    {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+        $island = Island::factory()->setUser($user2)->create();
+
+        $response = $this->actingAs($user1)
+            ->post('/api/islands/' . $island->id . '/comments', [
+                'comment' => 'test_comment',
+            ]);
+
+        $response->assertForbidden();
+        $this->assertNull(IslandComment::find(1));
+    }
+
+}

--- a/app/tests/App/Scnario/NextTurn.php
+++ b/app/tests/App/Scnario/NextTurn.php
@@ -1,92 +1,16 @@
 <?php
 
-namespace Tests\App\Http\Controllers\Api\Islands;
+namespace Tests\App\Scnario;
 
-use App\Models\Island;
-use App\Models\IslandComment;
-use App\Models\User;
+use Illuminate\Console\Command;
 use Tests\TestCase;
 
-class CommentsControllerTest extends TestCase
+class NextTurn extends TestCase
 {
-    public function testPostSuccess()
+    public function test()
     {
-        $user = User::factory()->create();
-        $island = Island::factory()->setUser($user)->create();
-
-        $response = $this->actingAs($user)
-            ->post('/api/islands/' . $island->id . '/comments', [
-                'comment' => 'test_comment',
-            ]);
-
-        $response->assertOk();
-        $this->assertSame(1, IslandComment::where('island_id', $island->id)->count());
-        $islandComment = IslandComment::where('island_id', $island->id)->first();
-        $this->assertSame($island->id, $islandComment->island_id);
-        $this->assertSame('test_comment', $islandComment->comment);
-        $this->assertSame('test_comment', json_decode($response->content())->comment);
-
-        $response = $this->actingAs($user)
-            ->post('/api/islands/' . $island->id . '/comments', [
-                'comment' => '',
-            ]);
-
-        $response->assertOk();
-        $this->assertSame(1, IslandComment::where('island_id', $island->id)->count());
-        $this->assertNull(IslandComment::find($islandComment->id));
-        $islandComment = IslandComment::where('island_id', $island->id)->first();
-        $this->assertSame($island->id, $islandComment->island_id);
-        $this->assertNull($islandComment->comment);
-        $this->assertNull(json_decode($response->content())->comment);
+        \Artisan::call('db:seed --class=RegisterIslandSeeder --env=testing');
+        $result = \Artisan::call('execute:turn --env=testing');
+        $this->assertSame(Command::SUCCESS, $result);
     }
-
-    public function testPostMaxChars()
-    {
-        $user = User::factory()->create();
-        $island = Island::factory()->setUser($user)->create();
-
-        $response = $this->actingAs($user)
-            ->post('/api/islands/' . $island->id . '/comments', [
-                'comment' => str_repeat('あ', 129),
-            ]);
-
-        $response->assertStatus(400);
-        $this->assertNull(IslandComment::find(1));
-
-        $response = $this->actingAs($user)
-            ->post('/api/islands/' . $island->id . '/comments', [
-                'comment' => str_repeat('あ', 128),
-            ]);
-
-        $response->assertOk();
-    }
-
-    public function testPostNotRegistered()
-    {
-        $user = User::factory()->create();
-
-        $response = $this->actingAs($user)
-            ->post('/api/islands/' . 1 . '/comments', [
-                'comment' => 'test_comment',
-            ]);
-
-        $response->assertForbidden();
-        $this->assertNull(IslandComment::find(1));
-    }
-
-    public function testPostTryOthersIsland()
-    {
-        $user1 = User::factory()->create();
-        $user2 = User::factory()->create();
-        $island = Island::factory()->setUser($user2)->create();
-
-        $response = $this->actingAs($user1)
-            ->post('/api/islands/' . $island->id . '/comments', [
-                'comment' => 'test_comment',
-            ]);
-
-        $response->assertForbidden();
-        $this->assertNull(IslandComment::find(1));
-    }
-
 }

--- a/infra/app/Dockerfile
+++ b/infra/app/Dockerfile
@@ -13,7 +13,6 @@ RUN \
     nginx \
     supervisor \
     iputils-ping net-tools \
-    graphviz \
     htop \
     vim \
     emacs \


### PR DESCRIPTION
## 概要

- 海賊を倒したときに懸賞金がもらえるよう処理を追加しました
    - 埋蔵金と同じで100億円〜1000億円の範囲です
- ついでにER図作成ライブラリをログがうるさかったので削除しました