### PR TITLE
デザイン修正およびiOSに起因する問題の解決

### DIFF
--- a/app/resources/css/app.scss
+++ b/app/resources/css/app.scss
@@ -125,6 +125,15 @@
 
 #index {
     @apply mx-auto max-w-[1000px] px-3;
+
+    .index-ranking-viewer {
+        @apply rounded-md;
+
+        .subtitle {
+            @apply rounded-t-md
+        }
+
+    }
 }
 
 #register {

--- a/app/resources/js/components/CommentForm.vue
+++ b/app/resources/js/components/CommentForm.vue
@@ -92,7 +92,9 @@ export default defineComponent({
         @apply flex justify-between;
 
         .comment-header-title {
-            @apply inline-block text-left bg-surface-variant text-on-surface-variant pt-1 px-4 rounded-t-2xl text-sm;
+            @apply inline-block text-left bg-surface-variant text-on-surface-variant pt-1 px-4 text-sm;
+            @apply rounded-tr-2xl;
+            @apply md:rounded-t-2xl;
         }
 
         .comment-update {
@@ -117,7 +119,8 @@ export default defineComponent({
     }
 
     .comment-body {
-        @apply bg-surface-variant -mt-0.5 p-2 rounded-tr-xl rounded-bl-xl rounded-br-xl;
+        @apply bg-surface-variant -mt-0.5 p-2;
+        @apply md:rounded-tr-xl md:rounded-bl-xl md:rounded-br-xl;
 
         #comment-input {
             @apply w-full bg-surface-variant text-on-surface-variant p-1 border border-background focus:outline-none rounded;

--- a/app/resources/js/components/LogViewer.vue
+++ b/app/resources/js/components/LogViewer.vue
@@ -139,7 +139,7 @@ export default defineComponent({
 
 #logs {
     // general
-    @apply text-left w-full mt-10 bg-surface pb-4 drop-shadow-md overflow-hidden;
+    @apply text-left w-full mt-10 bg-surface drop-shadow-md;
     @apply md:rounded-md;
 
     .subtitle {

--- a/app/resources/js/components/LogViewer.vue
+++ b/app/resources/js/components/LogViewer.vue
@@ -140,8 +140,7 @@ export default defineComponent({
 #logs {
     // general
     @apply text-left w-full mt-10 bg-surface pb-4 drop-shadow-md overflow-hidden;
-    // desktop
-    @apply lg:rounded-2xl;
+    @apply md:rounded-md;
 
     .subtitle {
         @apply mt-0 py-3 px-3 mb-3 w-full bg-primary text-on-primary font-bold;

--- a/app/resources/js/components/LogViewer.vue
+++ b/app/resources/js/components/LogViewer.vue
@@ -143,12 +143,12 @@ export default defineComponent({
     @apply md:rounded-md;
 
     .subtitle {
-        @apply mt-0 py-3 px-3 mb-3 w-full bg-primary text-on-primary font-bold;
+        @apply mt-0 py-3 px-3 mb-3 w-full bg-primary md:rounded-t-md text-on-primary font-bold;
     }
 
     .turn-log {
         // general
-        @apply flex items-start;
+        @apply flex items-start pb-3;
         // sp
         @apply text-sm mb-1 max-md:mt-4 max-md:pb-6 max-md:flex-wrap;
         // desktop

--- a/app/resources/js/components/RankingViewer.vue
+++ b/app/resources/js/components/RankingViewer.vue
@@ -2,7 +2,7 @@
         <div
             class="ranking"
             :id="'ranking-' + $props.island.id"
-            :class="[isAppeared ? 'animate-slide-in-left' : '']"
+            :class="[isAppeared ? 'active' : '']"
         >
             <div class="ranking-index">
                 <div class="ranking-index-num">{{ $props.index }}</div>
@@ -137,6 +137,15 @@ export default defineComponent({
         onAppeared() {
             this.isAppeared = true;
             this.observer.disconnect();
+
+            const target = document.getElementById("ranking-" + this.$props.island.id);
+            target.animate({
+                transform: ["translateX(-120%)", "translateX(0)"]
+            }, {
+                duration: 800,
+                easing: 'ease-in-out',
+                fill: "both",
+            })
         }
     },
     props: {
@@ -173,6 +182,7 @@ export default defineComponent({
 <style lang="scss" scoped>
 .ranking {
     @apply flex flex-wrap mb-3 p-0 rounded-xl border bg-surface drop-shadow-md text-on-surface;
+    transform: translateZ(0);
 
     .ranking-index {
         @apply flex items-center;
@@ -257,7 +267,5 @@ export default defineComponent({
         }
     }
 }
-
-
 
 </style>

--- a/app/resources/js/components/RankingViewer.vue
+++ b/app/resources/js/components/RankingViewer.vue
@@ -138,14 +138,14 @@ export default defineComponent({
             this.isAppeared = true;
             this.observer.disconnect();
 
-            const target = document.getElementById("ranking-" + this.$props.island.id);
-            target.animate({
-                transform: ["translateX(-120%)", "translateX(0)"]
-            }, {
-                duration: 800,
-                easing: 'ease-in-out',
-                fill: "both",
-            })
+            // const target = document.getElementById("ranking-" + this.$props.island.id);
+            // target.animate({
+            //     transform: ["translateX(-120%) translateZ(0)", "translateX(0) translateZ(0)"]
+            // }, {
+            //     duration: 800,
+            //     easing: 'ease-in-out',
+            //     fill: "both",
+            // })
         }
     },
     props: {
@@ -182,7 +182,10 @@ export default defineComponent({
 <style lang="scss" scoped>
 .ranking {
     @apply flex flex-wrap mb-3 p-0 rounded-xl border bg-surface drop-shadow-md text-on-surface;
-    transform: translateZ(0);
+
+    &.active {
+        @apply animate-slide-from-left;
+    }
 
     .ranking-index {
         @apply flex items-center;

--- a/app/resources/js/components/RankingViewer.vue
+++ b/app/resources/js/components/RankingViewer.vue
@@ -214,18 +214,21 @@ export default defineComponent({
                 @apply md:max-lg:border-none;
             }
             .ranking-summary-wrapper:nth-of-type(5) {
-                @apply md:border-none;
+                @apply lg:border-none;
             }
 
             .ranking-summary-data {
                 @apply flex items-end;
 
                 .ranking-summary-data-num {
-                    @apply grow text-base md:text-sm lg:text-lg inline-block text-right font-bold mr-2;
+                    @apply grow text-base inline-block text-right font-bold mr-2;
+                    @apply md:text-sm;
+                    @apply lg:text-lg lg:pb-1;
                 }
 
                 .ranking-summary-data-unit {
                     @apply text-xs w-1/6 text-right;
+                    @apply lg:text-[0.6rem]
                 }
             }
         }

--- a/app/resources/js/components/StatusTable.vue
+++ b/app/resources/js/components/StatusTable.vue
@@ -159,7 +159,6 @@ export default defineComponent({
         calcNumFontSizes() {
             this.statuses.forEach((stat, index) => {
                 const w = document.getElementById("data-num-" + index).clientWidth;
-                console.debug(w);
                 if(this.screenWidth < 768) { // Tailwind md:
                     stat.fontSize = w / (stat.numText.length*0.7);
                 } else if(this.screenWidth < 1024) {

--- a/app/resources/js/pages/PlanPage.vue
+++ b/app/resources/js/pages/PlanPage.vue
@@ -20,10 +20,12 @@
             ></plan-list>
         </div>
         <comment-form></comment-form>
-        <log-viewer
-            :title="store.island.name + '島の近況'"
-            :parsed-logs="store.logs"
-        ></log-viewer>
+        <div class="md:max-lg:px-3">
+            <log-viewer
+                :title="store.island.name + '島の近況'"
+                :parsed-logs="store.logs"
+            ></log-viewer>
+        </div>
         <island-popup></island-popup>
     </div>
 </template>

--- a/app/resources/js/pages/PlanPage.vue
+++ b/app/resources/js/pages/PlanPage.vue
@@ -176,7 +176,7 @@ export default defineComponent({
 <style lang="scss" scoped>
 
 #plan-page {
-    @apply text-center mx-auto max-w-[1000px] max-md:overflow-x-scroll min-h-[1200px]
+    @apply text-center mx-auto max-w-[1000px] min-h-[1200px];
 }
 
 </style>

--- a/app/resources/js/pages/SightseeingPage.vue
+++ b/app/resources/js/pages/SightseeingPage.vue
@@ -94,7 +94,7 @@ export default defineComponent({
 <style lang="scss" scoped>
 
 #sightseeing-page {
-    @apply text-center mx-auto max-w-[1000px] max-md:overflow-x-scroll min-h-[1200px]
+    @apply text-center mx-auto max-w-[1000px] min-h-[1200px];
 }
 
 </style>

--- a/app/resources/js/pages/SightseeingPage.vue
+++ b/app/resources/js/pages/SightseeingPage.vue
@@ -4,10 +4,12 @@
         <div class="link-text mb-5"><a href="/">トップへ戻る</a></div>
         <status-table></status-table>
         <island-viewer></island-viewer>
-        <log-viewer
-            :title="store.island.name + '島の近況'"
-            :parsed-logs="store.logs"
-        ></log-viewer>
+        <div class="md:max-lg:px-3">
+            <log-viewer
+                :title="store.island.name + '島の近況'"
+                :parsed-logs="store.logs"
+            ></log-viewer>
+        </div>
     </div>
 </template>
 

--- a/app/resources/views/pages/index.blade.php
+++ b/app/resources/views/pages/index.blade.php
@@ -32,6 +32,10 @@
             <h2 class="subtitle mt-20">現在のランキング</h2>
             <hr/>
 
+            @if(count($islands) === 0)
+                <p>島が登録されていません</p>
+            @endif
+
             @foreach($islands as $index => $island)
                 <ranking-viewer
                     :index="@js($index+1)"
@@ -39,10 +43,14 @@
                 ></ranking-viewer>
             @endforeach
 
-            <log-viewer
-                :title="'最近の出来事'"
-                :unparsed-logs="@js($logs)"
-            ></log-viewer>
+
+            @if(count($logs) > 0)
+                <log-viewer
+                    :title="'最近の出来事'"
+                    :unparsed-logs="@js($logs)"
+                ></log-viewer>
+            @endif
+
         </div>
         @include('components.footer')
     </div>

--- a/app/resources/views/pages/index.blade.php
+++ b/app/resources/views/pages/index.blade.php
@@ -46,6 +46,7 @@
 
             @if(count($logs) > 0)
                 <log-viewer
+                    class="rounded-md"
                     :title="'最近の出来事'"
                     :unparsed-logs="@js($logs)"
                 ></log-viewer>

--- a/app/resources/views/pages/index.blade.php
+++ b/app/resources/views/pages/index.blade.php
@@ -38,6 +38,7 @@
 
             @foreach($islands as $index => $island)
                 <ranking-viewer
+                    class="index-ranking-viewer rounded-md"
                     :index="@js($index+1)"
                     :island="@js($island)"
                 ></ranking-viewer>
@@ -46,7 +47,7 @@
 
             @if(count($logs) > 0)
                 <log-viewer
-                    class="rounded-md"
+                    class="index-ranking-viewer"
                     :title="'最近の出来事'"
                     :unparsed-logs="@js($logs)"
                 ></log-viewer>

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -54,7 +54,6 @@ module.exports = {
             animation: {
                 "fadein": "fadein 0.3s",
                 "fadeout-3s": "fadeout-3s 5.0s forwards",
-                "slide-in-left": "slide-in-left 1.2s"
             },
             keyframes: {
                 "fadein": {
@@ -69,16 +68,6 @@ module.exports = {
                     "0%": {opacity: 1},
                     "70%": {opacity: 1},
                     "100%": {opacity: 0}
-                },
-                "slide-in-left": {
-                    "0%": {
-                        transform: "translateX(-20%)",
-                        opacity: 0,
-                    },
-                    "100%": {
-                        transform: "translateX(0%)",
-                        opacity: 1
-                    }
                 },
             }
         },

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -54,6 +54,7 @@ module.exports = {
             animation: {
                 "fadein": "fadein 0.3s",
                 "fadeout-3s": "fadeout-3s 5.0s forwards",
+                "slide-from-left": "2s ease-in-out 0s 1 normal both running slide-from-left"
             },
             keyframes: {
                 "fadein": {
@@ -69,6 +70,16 @@ module.exports = {
                     "70%": {opacity: 1},
                     "100%": {opacity: 0}
                 },
+                "slide-from-left": {
+                    "0%": {
+                        opacity: 0,
+                        transform: "translateX(-120%) translateZ(0)"
+                    },
+                    "100%": {
+                        opacity: 1,
+                        transform: "translateX(0) translateZ(0)"
+                    }
+                }
             }
         },
     },


### PR DESCRIPTION
# Overview

デザインに関する修正を行いました。
見た目の変更というより、iOS対応のための処理方法の変更が中心です。

# Description

## 島未登録時のトップページの表示変更 (fixed #127)

島が登録されていないとき空白が表示されたりしてデザインがあまりよくなかったため、修正を行いました。

- RankingViewer
  「島が登録されていません」という表記が出るように変更
- LogViewer
  ログがないときは表示しないように実装を変更

![image](https://github.com/mjtakenon/hakoniwa/assets/130939038/b6a18b95-50e1-48da-a75e-42771e9090df)

## ランキングのデザイン修正 (fixed #123)

ランキングのデザイン修正を行いました。

- 億円の表記がlg:で縦書きになってしまい、それに引っ張られて値がずれる問題の修正
  ![image](https://github.com/mjtakenon/hakoniwa/assets/130939038/cc12d2fc-042f-4e53-8d16-f06bb059b0e6)

- md:max-lg:の時、「資源」のセクションの右側にborderが表示されずバランスが悪くなっていたため修正
  ![スクリーンショット 2023-06-06 142427](https://github.com/mjtakenon/hakoniwa/assets/130939038/0a2f5cee-3b7d-44a0-8c12-6791b05fb8c5)

## LogViewerのデザイン修正

- ボックスの角丸のRを微調整
- 島編集・閲覧画面でmd:max-lg:の時に左右にパディングが発生するように変更

![image](https://github.com/mjtakenon/hakoniwa/assets/130939038/64f51e12-79a0-4e92-b917-ff3282d90fc3)

## 島編集・閲覧画面のデザイン変更

- max-md:の時のコメント入力欄のデザイン変更
  ![image](https://github.com/mjtakenon/hakoniwa/assets/130939038/5ffba288-947b-408a-be7f-1c2dd963f116)

- max-md:にてx軸に不要なスクロールバーが表示される問題の修正
  - 以前デバッグ時に追加したものが残っていたようです。すいません。

## iOSデバイスでdrop-shadowが正常に機能しない問題の修正 (fixed #130)

本PRの一番大きい修正箇所です。
iOSデバイスでTailwindのdrop-shadowが機能しない問題を修正しました。
LogViewerとRankingViewerそれぞれ異なる要因でこの問題が発生していました。

### overflow-hidden問題の修正

iOSデバイスでは `overflow-hidden` と `drop-shadow` が同時にアタッチされているとき、overflowした分の影が切り取られてしまうため、四隅の角以外の影が表示されないようなおかしな表示になっていました。

本来親要素のroundedに合わせてoverflow: hiddenで切り取りたいところではありますが、LogViewerの `.subtitle` の中の要素も親要素と同じroundedを当てて、overflow-hiddenを取り除くことで対応しました。

### アニメーション終了時にdrop-shadowが消滅する問題の修正

今までの実装の場合、アニメーション終了時にdrop-shadowが正常に動作しなくなることがあり、上記overflow: hiddenの時と同じように影が四隅以外につかなくなることがあります。

原因としてはiOSでの実装の問題のようで、アニメーション終了時に自動的にGPUアクセラレーションが止まる仕様なのですが、これが **画面全体** のCSSのフィルタ要素を使ったプロパティに対しておかしなレンダリング結果が返ってくるように見えます。
質の悪いことに、アニメーションしていない全く関係ないDOM要素（LogViewer）のdrop-shadowが消えることもあるようですが、普通に書いてある<div>については影が消えないものの、Vueのコンポーネントに関しては消えてしまったためレンダリング方法による違いがありそうです。

対策として `transform: translateZ(0)` を指定することによりGPUレイヤーの作成を促すのが定石になっています。
https://zenn.dev/kibe/articles/659dadd1d6426c

またアニメーション終了時にtransformのパラメータを保持するようにしておかないと終了時にGPUレイヤーが削除されてしまうためアニメーションの実装についてもやや変更してあります。