### PR TITLE
島ステータスのリニューアル

### DIFF
--- a/app/resources/js/components/AchievementIcons.vue
+++ b/app/resources/js/components/AchievementIcons.vue
@@ -26,7 +26,12 @@
             </div>
         </template>
         <div v-else class="no-achievement">
-            実績なし
+            <div class="h-full flex items-center justify-center">
+                <div>
+                    実績なし
+                </div>
+            </div>
+
         </div>
     </div>
 
@@ -71,6 +76,7 @@ export default defineComponent({
 
         let cols = props.max_cols;
         if (achievements.length < cols)  cols = achievements.length;
+        if (cols === 0) cols = 1;
 
         return {achievements, cols};
     },
@@ -117,7 +123,7 @@ export default defineComponent({
 
 <style scoped lang="scss">
 .achievements {
-    @apply relative w-full grid;
+    @apply relative w-full grid min-h-full;
 
     .achievement {
         @apply flex flex-wrap justify-center leading-none my-1;

--- a/app/resources/js/components/CommentForm.vue
+++ b/app/resources/js/components/CommentForm.vue
@@ -86,7 +86,7 @@ export default defineComponent({
     // general
     @apply w-full my-4 text-left;
     // desktop
-    @apply md:px-10;
+    @apply md:px-4;
 
     .comment-header {
         @apply flex justify-between;

--- a/app/resources/js/components/StatusTable.vue
+++ b/app/resources/js/components/StatusTable.vue
@@ -133,8 +133,16 @@
                 </div>
             </div>
         </div>
-        <div class="stats-comments">
-            <!-- TODO:やる -->
+        <div class="stat-comment">
+            <div class="stat-comment-title">コメント</div>
+            <div v-if="store.island.comment === ''　|| store.island.comment === undefined || store.island.comment === null"
+                 class="stat-comment-empty"
+            >
+                コメントはありません
+            </div>
+            <div v-else class="stat-comment-main">
+                {{store.island.comment}}
+            </div>
         </div>
     </div>
 </template>
@@ -411,6 +419,22 @@ export default defineComponent({
                     }
                 }
             }
+        }
+    }
+
+    .stat-comment {
+        @apply mt-2 px-2 pb-2 border-t;
+
+        .stat-comment-title {
+            @apply text-left text-sm font-black;
+        }
+
+        .stat-comment-empty {
+            @apply text-sm text-on-secondary-container;
+        }
+
+        .stat-comment-main {
+            @apply px-2 text-left;
         }
     }
 }

--- a/app/resources/js/components/StatusTable.vue
+++ b/app/resources/js/components/StatusTable.vue
@@ -123,6 +123,9 @@
                 </div>
             </div>
         </div>
+        <div class="stats-comments">
+            <!-- TODO:やる -->
+        </div>
     </div>
 </template>
 
@@ -185,23 +188,10 @@ export default defineComponent({
         },
     },
     methods: {
-        calcNumFontSizes() {
-            this.statuses.forEach((stat, index) => {
-                const w = document.getElementById("data-num-" + index).clientWidth;
-                if(this.screenWidth < 768) { // Tailwind md:
-                    stat.fontSize = w / (stat.numText.length*0.7);
-                } else if(this.screenWidth < 1024) {
-                    stat.fontSize = w / (stat.numText.length*0.5);
-                } else {
-                    stat.fontSize = 124 / (stat.numText.length*0.5);
-                }
-            })
-        },
         onWindowSizeChanged() {
             const newScreenWidth = document.documentElement.clientWidth;
             if (this.screenWidth != newScreenWidth) {
                 this.isMobile = (document.documentElement.clientWidth < 1024);
-                this.calcNumFontSizes()
             }
         },
         updateStatus() {
@@ -267,9 +257,6 @@ export default defineComponent({
                     fontSize: 1
                 },
             ]
-            this.$nextTick(() => {
-                this.calcNumFontSizes();
-            })
         }
     }
 });
@@ -322,7 +309,8 @@ export default defineComponent({
 
                 .stat-box-num {
                     @apply grow min-w-0 text-on-surface text-right font-bold;
-                    @apply max-md:w-full max-md:px-2 max-md:mt-auto text-lg leading-none;
+                    @apply text-sm sm:text-lg;
+                    @apply max-md:w-full max-md:px-2 max-md:mt-auto leading-none;
                     @apply md:text-xl md:leading-none;
                 }
                 .stat-box-unit {
@@ -354,8 +342,8 @@ export default defineComponent({
 
             .stat-box-num {
                 @apply grow min-w-0 text-right font-bold;
-                @apply max-md:w-full max-md:px-1 text-lg leading-none;
-                @apply md:text-xl;
+                @apply max-md:w-full max-md:px-1;
+                @apply text-sm sm:text-lg sm:leading-none md:text-lg md:leading-none;
             }
 
             .stat-box-unit {
@@ -372,13 +360,16 @@ export default defineComponent({
                 @apply w-full text-on-surface-variant text-sm text-left font-bold leading-none;
             }
             .stat-inner {
-                @apply flex items-end w-full pb-2;
+                @apply flex flex-wrap gap-0 items-end w-full pb-2;
 
                 .stat-box-num {
                     @apply grow min-w-0 text-on-surface text-right font-bold text-xl leading-none;
+                    @apply max-md:w-full max-md:px-2 max-md:mt-auto text-lg leading-none;
+                    @apply text-lg md:text-xl;
                 }
                 .stat-box-unit {
-                    @apply ml-2 text-on-surface-variant leading-none;
+                    @apply ml-2 text-on-surface-variant leading-none text-right;
+                    @apply max-md:w-full max-md:text-xs max-md:leading-none;
                 }
             }
 

--- a/app/resources/js/components/StatusTable.vue
+++ b/app/resources/js/components/StatusTable.vue
@@ -2,8 +2,8 @@
     <div class="stats">
         <div class="stats-header">
             <div class="names">
-                <h1 class="island-name">{{store.island.name}}島</h1>
-                <span class="owner-name">({{store.island.owner_name}})</span>
+                <h1 class="island-name">{{ store.island.name }}島</h1>
+                <span class="owner-name">({{ store.island.owner_name }})</span>
             </div>
             <div class="header-achievements">
                 <achievement-icons :achievement_data="store.achievements"></achievement-icons>
@@ -15,7 +15,7 @@
                     <div class="stat-box-title">発展ポイント</div>
                     <div class="stat-inner">
                         <div class="stat-box-num">
-                            {{store.status.development_points.toLocaleString()}}
+                            {{ store.status.development_points.toLocaleString() }}
                         </div>
                         <div class="stat-box-unit">
                             pts
@@ -26,7 +26,7 @@
                     <div class="stat-box-title">面積</div>
                     <div class="stat-inner">
                         <div class="stat-box-num">
-                            {{store.status.area.toLocaleString()}}
+                            {{ store.status.area.toLocaleString() }}
                         </div>
                         <div class="stat-box-unit">
                             万坪
@@ -37,7 +37,7 @@
                     <div class="stat-box-title">環境</div>
                     <div class="stat-inner environment">
                         <div class="stat-box-num">
-                            {{store.getEnvironmentString}}
+                            {{ store.getEnvironmentString }}
                         </div>
                     </div>
                 </div>
@@ -47,21 +47,21 @@
                     <div class="stats-subtitle">島の情報</div>
                     <div class="stats-summary-inner">
                         <div class="stat-box-info">
-                            <font-awesome-icon icon="fa-solid fa-sack-dollar" class="stat-box-icon" />
+                            <font-awesome-icon icon="fa-solid fa-sack-dollar" class="stat-box-icon"/>
                             <div class="stat-box-title">資金</div>
-                            <div class="stat-box-num">{{store.status.funds.toLocaleString()}}</div>
+                            <div class="stat-box-num">{{ store.status.funds.toLocaleString() }}</div>
                             <div class="stat-box-unit">億円</div>
                         </div>
                         <div class="stat-box-info">
-                            <font-awesome-icon icon="fa-solid fa-wheat-awn" class="stat-box-icon" />
+                            <font-awesome-icon icon="fa-solid fa-wheat-awn" class="stat-box-icon"/>
                             <div class="stat-box-title">食料</div>
-                            <div class="stat-box-num">{{store.status.foods.toLocaleString()}}</div>
+                            <div class="stat-box-num">{{ store.status.foods.toLocaleString() }}</div>
                             <div class="stat-box-unit">㌧</div>
                         </div>
                         <div class="stat-box-info">
-                            <font-awesome-icon icon="fa-solid fa-oil-well" class="stat-box-icon" />
+                            <font-awesome-icon icon="fa-solid fa-oil-well" class="stat-box-icon"/>
                             <div class="stat-box-title">資源</div>
-                            <div class="stat-box-num">{{store.status.resources.toLocaleString()}}</div>
+                            <div class="stat-box-num">{{ store.status.resources.toLocaleString() }}</div>
                             <div class="stat-box-unit">㌧</div>
                         </div>
                     </div>
@@ -74,18 +74,20 @@
                                 <div class="stat-box-title">総人口</div>
                                 <div class="stat-inner">
                                     <div class="stat-box-num">
-                                        {{store.status.development_points.toLocaleString()}}
+                                        {{ store.status.population.toLocaleString() }}
                                     </div>
                                     <div class="stat-box-unit">
                                         人
                                     </div>
                                 </div>
                             </div>
-                            <div class="stat-box-human-left unassigned">
+                            <div class="stat-box-human-left unassigned"
+                                :class="{'plus': calcUnassigned > 0}"
+                            >
                                 <div class="stat-box-title">未割当</div>
                                 <div class="stat-inner">
                                     <div class="stat-box-num">
-                                        TODO
+                                        {{calcUnassigned.toLocaleString()}}
                                     </div>
                                     <div class="stat-box-unit">
                                         人
@@ -95,27 +97,35 @@
                         </div>
                         <div class="stats-human-right">
                             <div class="stat-box-info human">
-                                <font-awesome-icon icon="fa-solid fa-wheat-awn" class="stat-box-icon" />
+                                <font-awesome-icon icon="fa-solid fa-wheat-awn" class="stat-box-icon"/>
                                 <div class="stat-box-title">農業</div>
-                                <div class="stat-box-num">{{store.status.foods_production_capacity.toLocaleString()}}</div>
+                                <div class="stat-box-num">
+                                    {{ store.status.foods_production_capacity.toLocaleString() }}
+                                </div>
                                 <div class="stat-box-unit">人</div>
                             </div>
                             <div class="stat-box-info human">
-                                <font-awesome-icon icon="fa-solid fa-sack-dollar" class="stat-box-icon" />
+                                <font-awesome-icon icon="fa-solid fa-sack-dollar" class="stat-box-icon"/>
                                 <div class="stat-box-title">工業</div>
-                                <div class="stat-box-num">{{store.status.funds_production_capacity.toLocaleString()}}</div>
+                                <div class="stat-box-num">
+                                    {{ store.status.funds_production_capacity.toLocaleString() }}
+                                </div>
                                 <div class="stat-box-unit">人</div>
                             </div>
                             <div class="stat-box-info human">
-                                <font-awesome-icon icon="fa-solid fa-oil-well" class="stat-box-icon" />
+                                <font-awesome-icon icon="fa-solid fa-oil-well" class="stat-box-icon"/>
                                 <div class="stat-box-title">資源生産</div>
-                                <div class="stat-box-num">{{store.status.resources_production_capacity.toLocaleString()}}</div>
+                                <div class="stat-box-num">
+                                    {{ store.status.resources_production_capacity.toLocaleString() }}
+                                </div>
                                 <div class="stat-box-unit">人</div>
                             </div>
                             <div class="stat-box-info human">
                                 <font-awesome-icon icon="fa-solid fa-shield" class="stat-box-icon"/>
                                 <div class="stat-box-title">軍事</div>
-                                <div class="stat-box-num">TODO</div>
+                                <div class="stat-box-num">
+                                    {{ store.status.maintenance_number_of_people.toLocaleString() }}
+                                </div>
                                 <div class="stat-box-unit">人</div>
                             </div>
                         </div>
@@ -146,38 +156,28 @@ export default defineComponent({
             statuses: [] as {
                 title: string,
                 numText: string,
-                unit: string,
-                fontSize: number,
+                unit: string
             }[],
             isMobile: (document.documentElement.clientWidth < 1024),
             screenWidth: document.documentElement.clientWidth
         }
     },
     setup() {
-        library.add(faSackDollar,faWheatAwn,faOilWell, faShield)
+        library.add(faSackDollar, faWheatAwn, faOilWell, faShield)
 
         const store = useMainStore();
         const {status: statusRef} = storeToRefs(store);
         return {store, statusRef};
     },
-    watch: {
-        statusRef: {
-            handler() {
-                this.updateStatus();
-            },
-            deep: true,
-        }
-    },
     mounted() {
         window.addEventListener("resize", this.onWindowSizeChanged);
-        this.updateStatus();
     },
     unmounted() {
         window.removeEventListener("resize", this.onWindowSizeChanged);
     },
     computed: {
         hasComment() {
-            return this.store.island.comment === null　|| this.store.island.comment === undefined || this.store.island.comment === "";
+            return this.store.island.comment === null || this.store.island.comment === undefined || this.store.island.comment === "";
         },
         islandComment() {
             if (this.hasComment) {
@@ -185,6 +185,13 @@ export default defineComponent({
             } else {
                 return this.store.island.comment;
             }
+        },
+        calcUnassigned() {
+            return this.store.status.population -
+                this.store.status.foods_production_capacity -
+                this.store.status.funds_production_capacity -
+                this.store.status.resources_production_capacity -
+                this.store.status.maintenance_number_of_people;
         },
     },
     methods: {
@@ -194,70 +201,6 @@ export default defineComponent({
                 this.isMobile = (document.documentElement.clientWidth < 1024);
             }
         },
-        updateStatus() {
-            this.statuses = [
-                {
-                    title: "発展ポイント",
-                    numText: this.store.status.development_points.toLocaleString(),
-                    unit: "pts",
-                    fontSize: 1
-                },
-                {
-                    title: "人口",
-                    numText: this.store.status.population.toLocaleString(),
-                    unit: "人",
-                    fontSize: 1
-                },
-                {
-                    title: "資金",
-                    numText: this.store.status.funds.toLocaleString(),
-                    unit: "億円",
-                    fontSize: 1
-                },
-                {
-                    title: "食料",
-                    numText: this.store.status.foods.toLocaleString(),
-                    unit: "㌧",
-                    fontSize: 1
-                },
-                {
-                    title: "資源",
-                    numText: this.store.status.resources.toLocaleString(),
-                    unit: "㌧",
-                    fontSize: 1
-                },
-                {
-                    title: "環境",
-                    numText: this.store.getEnvironmentString,
-                    unit: "",
-                    fontSize: 1
-                },
-                {
-                    title: "面積",
-                    numText: this.store.status.area.toLocaleString(),
-                    unit: "万坪",
-                    fontSize: 1
-                },
-                {
-                    title: "農業",
-                    numText: this.store.status.foods_production_capacity.toLocaleString(),
-                    unit: "人規模",
-                    fontSize: 1
-                },
-                {
-                    title: "工業",
-                    numText: this.store.status.funds_production_capacity.toLocaleString(),
-                    unit: "人規模",
-                    fontSize: 1
-                },
-                {
-                    title: "資源生産",
-                    numText: this.store.status.resources_production_capacity.toLocaleString(),
-                    unit: "人規模",
-                    fontSize: 1
-                },
-            ]
-        }
     }
 });
 </script>
@@ -300,6 +243,7 @@ export default defineComponent({
             .stat-box-title {
                 @apply text-on-surface-variant text-sm text-left font-bold leading-none;
             }
+
             .stat-inner {
                 @apply flex flex-wrap text-right items-end mt-auto;
 
@@ -313,6 +257,7 @@ export default defineComponent({
                     @apply max-md:w-full max-md:px-2 max-md:mt-auto leading-none;
                     @apply md:text-xl md:leading-none;
                 }
+
                 .stat-box-unit {
                     @apply ml-2 text-on-surface-variant leading-none;
                     @apply max-md:w-full max-md:text-xs max-md:leading-none;
@@ -359,6 +304,7 @@ export default defineComponent({
             .stat-box-title {
                 @apply w-full text-on-surface-variant text-sm text-left font-bold leading-none;
             }
+
             .stat-inner {
                 @apply flex flex-wrap gap-0 items-end w-full pb-2;
 
@@ -367,6 +313,7 @@ export default defineComponent({
                     @apply max-md:w-full max-md:px-2 max-md:mt-auto text-lg leading-none;
                     @apply text-lg md:text-xl;
                 }
+
                 .stat-box-unit {
                     @apply ml-2 text-on-surface-variant leading-none text-right;
                     @apply max-md:w-full max-md:text-xs max-md:leading-none;
@@ -376,9 +323,10 @@ export default defineComponent({
             &.population {
                 @apply bg-primary;
 
-                .stat-box-title,.stat-box-unit {
+                .stat-box-title, .stat-box-unit {
                     @apply text-on-primary;
                 }
+
                 .stat-box-num {
                     @apply text-surface;
                 }
@@ -387,11 +335,20 @@ export default defineComponent({
             &.unassigned {
                 @apply bg-primary-container;
 
-                .stat-box-title,.stat-box-unit {
+                .stat-box-title, .stat-box-unit {
                     @apply text-on-primary-container;
                 }
+
                 .stat-box-num {
                     @apply text-on-surface;
+                }
+
+                &.plus {
+                    @apply bg-minus dark:bg-on-minus text-on-minus dark:text-minus;
+
+                    .stat-box-title, .stat-box-unit, .stat-box-num {
+                        @apply text-on-minus dark:text-minus;
+                    }
                 }
             }
         }
@@ -405,10 +362,12 @@ export default defineComponent({
                 @apply w-2/5;
                 @apply md:w-1/2;
             }
+
             .data-area {
                 @apply w-2/5;
                 @apply md:w-1/4;
             }
+
             .data-environment {
                 @apply w-1/5;
                 @apply md:w-1/4;
@@ -439,15 +398,15 @@ export default defineComponent({
                 @apply md:w-2/3;
 
                 .stats-human-inner {
-                    @apply flex items-stretch;
+                    @apply flex;
                     @apply gap-2;
                     @apply md:gap-4;
 
                     .stats-human-left {
-                        @apply flex flex-wrap
+                        @apply md:flex md:flex-wrap
                     }
 
-                    .stats-human-left,.stats-human-right {
+                    .stats-human-left, .stats-human-right {
                         @apply w-1/2;
                     }
                 }

--- a/app/resources/js/components/StatusTable.vue
+++ b/app/resources/js/components/StatusTable.vue
@@ -1,46 +1,126 @@
 <template>
     <div class="stats">
-        <div
-            v-for="(status, index) in statuses"
-            class="stats-box"
-            :class="{'max-md:col-span-3': (index === 0)}"
-            :key="status.title"
-        >
-            <div class="stats-box-title">
-                {{ status.title }}
+        <div class="stats-header">
+            <div class="names">
+                <h1 class="island-name">{{store.island.name}}島</h1>
+                <span class="owner-name">({{store.island.owner_name}})</span>
             </div>
-            <div class="stats-box-data">
-                <div
-                    class="stats-box-num-wrapper"
-                    :id="'data-num-' + index"
-                >
-                    <div
-                        class="stats-box-data-num"
-                        :style="this.isMobile ?
-                            {fontSize: 'clamp(1px,'+ status.fontSize +'px,1.05rem)'} :
-                            {fontSize: 'clamp(1px,'+ status.fontSize +'px,1.2rem)'}
-                        "
-                    >
-                        {{ status.numText }}
+            <div class="header-achievements">
+                <achievement-icons :achievement_data="store.achievements"></achievement-icons>
+            </div>
+        </div>
+        <div class="stats-contents">
+            <div class="stats-island">
+                <div class="data-point stat-box-island border-b">
+                    <div class="stat-box-title">発展ポイント</div>
+                    <div class="stat-inner">
+                        <div class="stat-box-num">
+                            {{store.status.development_points.toLocaleString()}}
+                        </div>
+                        <div class="stat-box-unit">
+                            pts
+                        </div>
                     </div>
                 </div>
-                <div class="stat-box-data-unit">
-                    {{ status.unit }}
+                <div class="data-area stat-box-island border-b">
+                    <div class="stat-box-title">面積</div>
+                    <div class="stat-inner">
+                        <div class="stat-box-num">
+                            {{store.status.area.toLocaleString()}}
+                        </div>
+                        <div class="stat-box-unit">
+                            万坪
+                        </div>
+                    </div>
+                </div>
+                <div class="data-environment stat-box-island border-b">
+                    <div class="stat-box-title">環境</div>
+                    <div class="stat-inner">
+                        <div class="stat-box-num">
+                            {{store.getEnvironmentString}}
+                        </div>
+                        <div class="stat-box-unit">
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="stats-box achievements-box">
-            <div class="stats-box-title">
-                実績
-            </div>
-            <achievement-icons class="achievement-icons" :achievement_data="store.achievements"></achievement-icons>
-        </div>
-        <div class="stats-box comment-box">
-            <div class="stats-box-title">
-                コメント
-            </div>
-            <div class="island-comment" :class="{'text-sm text-on-surface-variant': hasComment}">
-                {{ islandComment }}
+            <div class="stats-info">
+                <div class="stats-summary">
+                    <div class="stats-subtitle">島の情報</div>
+                    <div class="stat-box-info">
+                        <font-awesome-icon icon="fa-solid fa-sack-dollar" class="stat-box-icon" />
+                        <div class="stat-box-title">資金</div>
+                        <div class="stat-box-num">{{store.status.funds.toLocaleString()}}</div>
+                        <div class="stat-box-unit">億円</div>
+                    </div>
+                    <div class="stat-box-info">
+                        <font-awesome-icon icon="fa-solid fa-wheat-awn" class="stat-box-icon" />
+                        <div class="stat-box-title">食料</div>
+                        <div class="stat-box-num">{{store.status.foods.toLocaleString()}}</div>
+                        <div class="stat-box-unit">㌧</div>
+                    </div>
+                    <div class="stat-box-info">
+                        <font-awesome-icon icon="fa-solid fa-oil-well" class="stat-box-icon" />
+                        <div class="stat-box-title">資源</div>
+                        <div class="stat-box-num">{{store.status.resources.toLocaleString()}}</div>
+                        <div class="stat-box-unit">㌧</div>
+                    </div>
+                </div>
+                <div class="stats-human">
+                    <div class="stats-subtitle">人的資源</div>
+                    <div class="stats-human-inner">
+                        <div class="stats-human-left">
+                            <div class="stat-box-human-left population">
+                                <div class="stat-box-title">総人口</div>
+                                <div class="stat-inner">
+                                    <div class="stat-box-num">
+                                        {{store.status.development_points.toLocaleString()}}
+                                    </div>
+                                    <div class="stat-box-unit">
+                                        人
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="stat-box-human-left unassigned">
+                                <div class="stat-box-title">未割当</div>
+                                <div class="stat-inner">
+                                    <div class="stat-box-num">
+                                        TODO
+                                    </div>
+                                    <div class="stat-box-unit">
+                                        人
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="stats-human-right">
+                            <div class="stat-box-info">
+                                <font-awesome-icon icon="fa-solid fa-wheat-awn" class="stat-box-icon" />
+                                <div class="stat-box-title">農業</div>
+                                <div class="stat-box-num">{{store.status.foods_production_capacity.toLocaleString()}}</div>
+                                <div class="stat-box-unit">人</div>
+                            </div>
+                            <div class="stat-box-info">
+                                <font-awesome-icon icon="fa-solid fa-sack-dollar" class="stat-box-icon" />
+                                <div class="stat-box-title">工業</div>
+                                <div class="stat-box-num">{{store.status.funds_production_capacity.toLocaleString()}}</div>
+                                <div class="stat-box-unit">人</div>
+                            </div>
+                            <div class="stat-box-info">
+                                <font-awesome-icon icon="fa-solid fa-oil-well" class="stat-box-icon" />
+                                <div class="stat-box-title">資源生産</div>
+                                <div class="stat-box-num">{{store.status.resources_production_capacity.toLocaleString()}}</div>
+                                <div class="stat-box-unit">人</div>
+                            </div>
+                            <div class="stat-box-info">
+                                <font-awesome-icon icon="fa-solid fa-shield" class="stat-box-icon"/>
+                                <div class="stat-box-title">軍事</div>
+                                <div class="stat-box-num">TODO</div>
+                                <div class="stat-box-unit">人</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -51,6 +131,8 @@ import {defineComponent} from "vue";
 import {useMainStore} from "../store/MainStore";
 import AchievementIcons from "./AchievementIcons.vue";
 import {storeToRefs} from "pinia";
+import {library} from "@fortawesome/fontawesome-svg-core";
+import {faOilWell, faSackDollar, faShield, faWheatAwn} from "@fortawesome/free-solid-svg-icons";
 
 export default defineComponent({
     components: {
@@ -69,6 +151,8 @@ export default defineComponent({
         }
     },
     setup() {
+        library.add(faSackDollar,faWheatAwn,faOilWell, faShield)
+
         const store = useMainStore();
         const {status: statusRef} = storeToRefs(store);
         return {store, statusRef};
@@ -193,45 +277,149 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .stats {
-    @apply container px-2 py-1 md:mx-auto mb-3 md:mb-6 max-w-full grid grid-cols-3 md:grid-cols-5 gap-2;
+    @apply container mx-auto w-full bg-surface text-on-surface drop-shadow-md rounded-lg mb-4;
+    @apply md:py-2 md:px-4;
 
-    .stats-box {
-        @apply bg-surface-variant rounded-xl p-2 drop-shadow-md;
+    .stats-header {
+        @apply w-full flex py-3 mb-4 border-b-2 border-dashed;
 
-        .stats-box-title {
-            @apply font-bold text-left text-on-surface-variant text-xs lg:text-sm;
+        .names {
+            @apply grow flex items-end justify-center min-w-0;
+
+            .island-name {
+                @apply font-bold text-2xl mr-2;
+            }
+
+            .owner-name {
+                @apply text-on-surface-variant text-sm;
+            }
         }
 
-        .stats-box-data {
-            @apply flex items-end flex-wrap h-8;
-
-            .stats-box-num-wrapper {
-                @apply max-lg:w-full lg:grow min-w-0 text-right;
-            }
-
-            .stats-box-data-num {
-                @apply font-bold w-full inline;
-            }
-
-            .stat-box-data-unit {
-                @apply max-lg:w-full max-lg:-mt-1.5 text-[0.6rem] lg:text-sm text-right lg:pl-2;
-            }
+        .header-achievements {
+            @apply w-full;
+            @apply md:w-fit md:border-l md:min-w-[20%];
         }
     }
 
-    .achievements-box {
-        @apply col-span-3 md:col-span-2 z-10;
+    .stats-contents {
+        @apply w-full;
 
-        .achievement-icons {
-            @apply w-fit max-w-full mx-auto;
+        .stat-box-island {
+            @apply py-1;
+
+            .stat-box-title {
+                @apply text-on-surface-variant text-sm text-left font-bold leading-none;
+            }
+            .stat-inner {
+                @apply flex items-end;
+
+                .stat-box-num {
+                    @apply grow min-w-0 text-on-surface text-right font-bold text-xl leading-none;
+                }
+                .stat-box-unit {
+                    @apply ml-2 text-on-surface-variant leading-none;
+                }
+            }
         }
-    }
 
-    .comment-box {
-        @apply col-span-3;
+        .stat-box-info {
+            @apply flex items-center gap-2 py-1 px-2 rounded-lg bg-surface-variant text-on-surface-variant mb-1.5;
 
-        .island-comment {
-            @apply px-2 md:px-4 my-1 text-left leading-none;
+            .stat-box-icon {
+                @apply text-xl;
+            }
+
+            .stat-box-title {
+                @apply text-sm font-bold;
+            }
+
+            .stat-box-num {
+                @apply grow min-w-0 text-right font-bold text-xl;
+            }
+
+            .stat-box-unit {
+                @apply mt-auto text-xs text-right w-[24px];
+            }
+        }
+
+        .stat-box-human-left {
+            @apply flex flex-wrap py-1 px-2 w-full grow rounded-lg mb-2;
+
+            .stat-box-title {
+                @apply w-full text-on-surface-variant text-sm text-left font-bold leading-none;
+            }
+            .stat-inner {
+                @apply flex items-end w-full pb-2;
+
+                .stat-box-num {
+                    @apply grow min-w-0 text-on-surface text-right font-bold text-xl leading-none;
+                }
+                .stat-box-unit {
+                    @apply ml-2 text-on-surface-variant leading-none;
+                }
+            }
+
+            &.population {
+                @apply bg-primary;
+
+                .stat-box-title,.stat-box-unit {
+                    @apply text-on-primary;
+                }
+                .stat-box-num {
+                    @apply text-surface;
+                }
+            }
+
+            &.unassigned {
+                @apply bg-primary-container;
+
+                .stat-box-title,.stat-box-unit {
+                    @apply text-on-primary-container;
+                }
+                .stat-box-num {
+                    @apply text-on-surface;
+                }
+            }
+        }
+
+        .stats-island {
+            @apply flex mb-6;
+            @apply md:gap-8;
+
+            .data-point {
+                @apply w-1/2;
+            }
+            .data-area,.data-environment {
+                @apply w-1/4;
+            }
+        }
+
+        .stats-info {
+            @apply flex;
+            @apply md:gap-10;
+
+            .stats-subtitle {
+                @apply text-left font-bold text-on-surface-variant text-sm;
+            }
+
+            .stats-summary {
+                @apply w-1/3;
+            }
+            .stats-human {
+                @apply w-2/3;
+
+                .stats-human-inner {
+                    @apply flex gap-4 items-stretch;
+
+                    .stats-human-left {
+                        @apply flex flex-wrap
+                    }
+
+                    .stats-human-left,.stats-human-right {
+                        @apply w-1/2;
+                    }
+                }
+            }
         }
     }
 }

--- a/app/resources/js/components/StatusTable.vue
+++ b/app/resources/js/components/StatusTable.vue
@@ -35,11 +35,9 @@
                 </div>
                 <div class="data-environment stat-box-island border-b">
                     <div class="stat-box-title">環境</div>
-                    <div class="stat-inner">
+                    <div class="stat-inner environment">
                         <div class="stat-box-num">
                             {{store.getEnvironmentString}}
-                        </div>
-                        <div class="stat-box-unit">
                         </div>
                     </div>
                 </div>
@@ -47,23 +45,25 @@
             <div class="stats-info">
                 <div class="stats-summary">
                     <div class="stats-subtitle">島の情報</div>
-                    <div class="stat-box-info">
-                        <font-awesome-icon icon="fa-solid fa-sack-dollar" class="stat-box-icon" />
-                        <div class="stat-box-title">資金</div>
-                        <div class="stat-box-num">{{store.status.funds.toLocaleString()}}</div>
-                        <div class="stat-box-unit">億円</div>
-                    </div>
-                    <div class="stat-box-info">
-                        <font-awesome-icon icon="fa-solid fa-wheat-awn" class="stat-box-icon" />
-                        <div class="stat-box-title">食料</div>
-                        <div class="stat-box-num">{{store.status.foods.toLocaleString()}}</div>
-                        <div class="stat-box-unit">㌧</div>
-                    </div>
-                    <div class="stat-box-info">
-                        <font-awesome-icon icon="fa-solid fa-oil-well" class="stat-box-icon" />
-                        <div class="stat-box-title">資源</div>
-                        <div class="stat-box-num">{{store.status.resources.toLocaleString()}}</div>
-                        <div class="stat-box-unit">㌧</div>
+                    <div class="stats-summary-inner">
+                        <div class="stat-box-info">
+                            <font-awesome-icon icon="fa-solid fa-sack-dollar" class="stat-box-icon" />
+                            <div class="stat-box-title">資金</div>
+                            <div class="stat-box-num">{{store.status.funds.toLocaleString()}}</div>
+                            <div class="stat-box-unit">億円</div>
+                        </div>
+                        <div class="stat-box-info">
+                            <font-awesome-icon icon="fa-solid fa-wheat-awn" class="stat-box-icon" />
+                            <div class="stat-box-title">食料</div>
+                            <div class="stat-box-num">{{store.status.foods.toLocaleString()}}</div>
+                            <div class="stat-box-unit">㌧</div>
+                        </div>
+                        <div class="stat-box-info">
+                            <font-awesome-icon icon="fa-solid fa-oil-well" class="stat-box-icon" />
+                            <div class="stat-box-title">資源</div>
+                            <div class="stat-box-num">{{store.status.resources.toLocaleString()}}</div>
+                            <div class="stat-box-unit">㌧</div>
+                        </div>
                     </div>
                 </div>
                 <div class="stats-human">
@@ -94,25 +94,25 @@
                             </div>
                         </div>
                         <div class="stats-human-right">
-                            <div class="stat-box-info">
+                            <div class="stat-box-info human">
                                 <font-awesome-icon icon="fa-solid fa-wheat-awn" class="stat-box-icon" />
                                 <div class="stat-box-title">農業</div>
                                 <div class="stat-box-num">{{store.status.foods_production_capacity.toLocaleString()}}</div>
                                 <div class="stat-box-unit">人</div>
                             </div>
-                            <div class="stat-box-info">
+                            <div class="stat-box-info human">
                                 <font-awesome-icon icon="fa-solid fa-sack-dollar" class="stat-box-icon" />
                                 <div class="stat-box-title">工業</div>
                                 <div class="stat-box-num">{{store.status.funds_production_capacity.toLocaleString()}}</div>
                                 <div class="stat-box-unit">人</div>
                             </div>
-                            <div class="stat-box-info">
+                            <div class="stat-box-info human">
                                 <font-awesome-icon icon="fa-solid fa-oil-well" class="stat-box-icon" />
                                 <div class="stat-box-title">資源生産</div>
                                 <div class="stat-box-num">{{store.status.resources_production_capacity.toLocaleString()}}</div>
                                 <div class="stat-box-unit">人</div>
                             </div>
-                            <div class="stat-box-info">
+                            <div class="stat-box-info human">
                                 <font-awesome-icon icon="fa-solid fa-shield" class="stat-box-icon"/>
                                 <div class="stat-box-title">軍事</div>
                                 <div class="stat-box-num">TODO</div>
@@ -281,10 +281,12 @@ export default defineComponent({
     @apply md:py-2 md:px-4;
 
     .stats-header {
-        @apply w-full flex py-3 mb-4 border-b-2 border-dashed;
+        @apply w-full py-3 mb-4 border-b-2 border-dashed;
+        @apply md:flex;
 
         .names {
             @apply grow flex items-end justify-center min-w-0;
+            @apply max-md:w-full;
 
             .island-name {
                 @apply font-bold text-2xl mr-2;
@@ -303,6 +305,7 @@ export default defineComponent({
 
     .stats-contents {
         @apply w-full;
+        @apply max-md:px-2;
 
         .stat-box-island {
             @apply py-1;
@@ -311,34 +314,54 @@ export default defineComponent({
                 @apply text-on-surface-variant text-sm text-left font-bold leading-none;
             }
             .stat-inner {
-                @apply flex items-end;
+                @apply flex flex-wrap text-right items-end mt-auto;
+
+                &.environment {
+                    @apply mt-2;
+                }
 
                 .stat-box-num {
-                    @apply grow min-w-0 text-on-surface text-right font-bold text-xl leading-none;
+                    @apply grow min-w-0 text-on-surface text-right font-bold;
+                    @apply max-md:w-full max-md:px-2 max-md:mt-auto text-lg leading-none;
+                    @apply md:text-xl md:leading-none;
                 }
                 .stat-box-unit {
                     @apply ml-2 text-on-surface-variant leading-none;
+                    @apply max-md:w-full max-md:text-xs max-md:leading-none;
                 }
             }
         }
 
         .stat-box-info {
-            @apply flex items-center gap-2 py-1 px-2 rounded-lg bg-surface-variant text-on-surface-variant mb-1.5;
+            @apply flex items-center py-1 px-2 rounded-lg bg-surface-variant text-on-surface-variant mb-1.5;
+            @apply max-md:w-1/3 max-md:flex-wrap;
+            @apply md:gap-2;
+
+            &.human {
+                @apply max-md:w-full;
+            }
 
             .stat-box-icon {
-                @apply text-xl;
+                @apply text-sm;
+                @apply md:text-xl;
             }
 
             .stat-box-title {
-                @apply text-sm font-bold;
+                @apply font-bold;
+                @apply text-xs;
+                @apply md:text-sm;
             }
 
             .stat-box-num {
-                @apply grow min-w-0 text-right font-bold text-xl;
+                @apply grow min-w-0 text-right font-bold;
+                @apply max-md:w-full max-md:px-1 text-lg leading-none;
+                @apply md:text-xl;
             }
 
             .stat-box-unit {
-                @apply mt-auto text-xs text-right w-[24px];
+                @apply mt-auto text-right;
+                @apply max-md:w-full text-[0.5rem] leading-none;
+                @apply md:text-xs md:w-[24px];
             }
         }
 
@@ -383,33 +406,51 @@ export default defineComponent({
         }
 
         .stats-island {
-            @apply flex mb-6;
-            @apply md:gap-8;
+            @apply flex;
+            @apply gap-3 mb-2;
+            @apply md:gap-8 md:mb-6;
 
             .data-point {
-                @apply w-1/2;
+                @apply w-2/5;
+                @apply md:w-1/2;
             }
-            .data-area,.data-environment {
-                @apply w-1/4;
+            .data-area {
+                @apply w-2/5;
+                @apply md:w-1/4;
+            }
+            .data-environment {
+                @apply w-1/5;
+                @apply md:w-1/4;
             }
         }
 
         .stats-info {
             @apply flex;
+            @apply max-md:flex-wrap;
             @apply md:gap-10;
 
             .stats-subtitle {
                 @apply text-left font-bold text-on-surface-variant text-sm;
+                @apply max-md:w-full;
             }
 
             .stats-summary {
-                @apply w-1/3;
+                @apply w-full;
+                @apply md:w-1/3;
+
+                .stats-summary-inner {
+                    @apply max-md:flex max-md:gap-1;
+                }
             }
+
             .stats-human {
-                @apply w-2/3;
+                @apply w-full;
+                @apply md:w-2/3;
 
                 .stats-human-inner {
-                    @apply flex gap-4 items-stretch;
+                    @apply flex items-stretch;
+                    @apply gap-2;
+                    @apply md:gap-4;
 
                     .stats-human-left {
                         @apply flex flex-wrap

--- a/app/resources/js/pages/PlanPage.vue
+++ b/app/resources/js/pages/PlanPage.vue
@@ -1,7 +1,5 @@
 <template>
     <div id="plan-page">
-        <div class="title mt-2">{{ store.island.name }}島開発計画</div>
-        <div class="link-text mb-5"><a href="/">トップへ戻る</a></div>
         <status-table></status-table>
         <comment-form></comment-form>
         <div class="flex flex-wrap items-stretch mx-auto justify-center mt-10">

--- a/app/resources/js/pages/SightseeingPage.vue
+++ b/app/resources/js/pages/SightseeingPage.vue
@@ -1,7 +1,5 @@
 <template>
     <div id="sightseeing-page" class="wrapper">
-        <div class="title mt-2">{{ store.island.name }}島へようこそ！</div>
-        <div class="link-text mb-5"><a href="/">トップへ戻る</a></div>
         <status-table></status-table>
         <island-viewer></island-viewer>
         <div class="md:max-lg:px-3">

--- a/app/resources/js/store/Entity/Status.ts
+++ b/app/resources/js/store/Entity/Status.ts
@@ -9,5 +9,6 @@ export interface Status {
     population: number,
     resources: number,
     resources_production_capacity: number,
+    maintenance_number_of_people: number,
     abandonment_turn: number,
 }

--- a/app/resources/js/store/MainStore.ts
+++ b/app/resources/js/store/MainStore.ts
@@ -67,6 +67,7 @@ export const useMainStore = defineStore('main', {
                 population: 0,
                 resources: 0,
                 resources_production_capacity: 0,
+                maintenance_number_of_people: 0,
                 abandonment_turn: 0,
             },
             logs: [],


### PR DESCRIPTION
# Overview

100年ぶりぐらいにやりかけのPRを思い出したので実装
直近でReactを触る予定があるので、記憶が汚染される前にやりました
resolve #143 

# Description

全体的にレイアウトを変更しています。
- アイコンを追加してUXを向上しました
- 複雑になりすぎたこと・計算量が一気に増えてしまったため、フォントサイズの調整をbreakpointベースの決め打ちに戻しました
- 島の概要（発展ポイント等）、島の情報（資源等）、人的資源の状況で3セクションに分けて視認性を上げました。
- 軍事の維持人数を表示できるようにstoreの変更、表示部の追加
- 総人口 - 各維持人数を計算し、未割当の人数を表示
- 未割当が1以上の時、表示枠や文字がerror色になる機能の実装

スクショにはありませんが、ダークテーマも確認・調整済みです。
久々だったのでバグないか念入りにチェックしたので、恐らく大丈夫なはず…

### Phone 
![image](https://github.com/mjtakenon/hakoniwa/assets/130939038/7d5f969e-cafb-45ab-a195-86db8a3219f1)

### Desktop
![image](https://github.com/mjtakenon/hakoniwa/assets/130939038/90c22bf3-3cf9-4a00-a632-fc0534d1a84b)

