### PR TITLE
Prettierのセッティング・.editorconfigの再設定

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/app/.editorconfig
+++ b/app/.editorconfig
@@ -1,8 +1,4 @@
-root = true
-
-[*]
-charset = utf-8
-end_of_line = lf
+[*.php]
 indent_size = 4
 indent_style = space
 insert_final_newline = true
@@ -10,9 +6,3 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
-
-[*.{yml,yaml}]
-indent_size = 2
-
-[docker-compose.yml]
-indent_size = 4

--- a/app/.prettierignore
+++ b/app/.prettierignore
@@ -1,0 +1,17 @@
+# Laravel
+app
+bootstrap
+config
+database
+lang
+routes
+storage
+tests
+vendor
+
+# GLTF ignore
+**/*/*.gltf
+**/*/*.glb
+
+# Composer
+composer.lock

--- a/app/.prettierrc.js
+++ b/app/.prettierrc.js
@@ -1,0 +1,15 @@
+/** @type {import("prettier").Config} */
+const config = {
+  trailingComma: 'none',
+  printWidth: 120,
+  tabWidth: 2,
+  useTabs: false,
+  semi: false,
+  singleQuote: true,
+  endOfLine: 'lf',
+  bracketSameLine: true,
+  vueIndentScriptAndStyle: false,
+  plugins: ['prettier-plugin-tailwindcss']
+}
+
+export default config

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,9 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "vite build"
+        "build": "vite build",
+        "prettier-format": "prettier . --write",
+        "prettier-check": "prettier . --check"
     },
     "devDependencies": {
         "@types/lodash": "^4.14.192",
@@ -14,6 +16,8 @@
         "autoprefixer": "^10.4.14",
         "laravel-vite-plugin": "^0.7.5",
         "postcss": "^8.4.23",
+        "prettier": "^3.1.1",
+        "prettier-plugin-tailwindcss": "^0.5.11",
         "sass": "^1.60.0",
         "tailwindcss": "^3.3.2",
         "vite": "^4.3.8"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1061,6 +1061,16 @@ potpack@^1.0.1:
   resolved "https://registry.yarnpkg.com/potpack/-/potpack-1.0.2.tgz#23b99e64eb74f5741ffe7656b5b5c4ddce8dfc14"
   integrity sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==
 
+prettier-plugin-tailwindcss@^0.5.11:
+  version "0.5.11"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.11.tgz#1aa9308c3285b3cb7942aaeaec8d0e0775ac54d0"
+  integrity sha512-AvI/DNyMctyyxGOjyePgi/gqj5hJYClZ1avtQvLlqMT3uDZkRbi4HhGUpok3DRzv9z7Lti85Kdj3s3/1CeNI0w==
+
+prettier@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.1.1.tgz#6ba9f23165d690b6cbdaa88cb0807278f7019848"
+  integrity sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==
+
 proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"


### PR DESCRIPTION
## Overview

- prettierを導入および `.prettierrc`, `prettierignore` の設定
- tailwindcssのprettier pluginを導入・設定しました
- package.jsonに実行用のコマンド追加
- EditorConfigを一部ルートディレクトリに移動、PHP用フォーマット設定が `[*]` になっていたため変更