### PR TITLE
Settings, Releasesページのリファクタおよびバグ修正

### DIFF
--- a/app/resources/js/app.ts
+++ b/app/resources/js/app.ts
@@ -1,4 +1,4 @@
 import './bootstrap'
-import { app } from './bootstrap'
+import { app } from './bootstrap.js'
 
 app.mount('#app')

--- a/app/resources/js/bootstrap.ts
+++ b/app/resources/js/bootstrap.ts
@@ -16,7 +16,7 @@ axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest'
 window.axios = axios
 
 import { App } from 'vue'
-import { createApp } from 'vue/dist/vue.esm-bundler'
+import { createApp } from 'vue/dist/vue.esm-bundler.js'
 import { createPinia } from 'pinia'
 import Tres from '@tresjs/core'
 import IslandsPage from './components/pages/Islands/IslandsPage.vue'

--- a/app/resources/js/components/layout/DebugTools.vue
+++ b/app/resources/js/components/layout/DebugTools.vue
@@ -4,7 +4,7 @@
     :class="{ hidden: !visible }">
     <div class="mr-5 text-xs">DEBUG TOOLS:</div>
     <div class="text-xs">theme:</div>
-    <ThemeSwitcher></ThemeSwitcher>
+    <ThemeSwitcher />
     <a v-if="debugLoginUsingId >= 1" class="button-primary login" href="/auth/debug/login">
       <div>ログイン</div>
     </a>

--- a/app/resources/js/components/pages/Releases/ReleasesMarkdown.vue
+++ b/app/resources/js/components/pages/Releases/ReleasesMarkdown.vue
@@ -2,32 +2,21 @@
   <div class="markdown" v-html="html"></div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue'
+<script setup lang="ts">
+import { computed } from 'vue'
 import MarkdownIt from 'markdown-it'
-// Typescript未対応の為
-// @ts-ignore
 import sanitizer from 'markdown-it-sanitizer'
 
-export default defineComponent({
-  setup() {
-    const markdown = new MarkdownIt({
-      html: true
-    }).use(sanitizer)
-    return { markdown }
-  },
-  computed: {
-    html() {
-      return this.markdown.render(this.sources)
-    }
-  },
-  props: {
-    sources: {
-      required: true,
-      type: String
-    }
-  }
+interface Props {
+  sources: string
+}
+const props = defineProps<Props>()
+
+const markdown = new MarkdownIt({
+  html: true
+}).use(sanitizer)
+
+const html = computed(() => {
+  return markdown.render(props.sources)
 })
 </script>
-
-<style scoped lang="scss"></style>

--- a/app/resources/js/components/pages/Settings/SettingsPage.vue
+++ b/app/resources/js/components/pages/Settings/SettingsPage.vue
@@ -2,48 +2,38 @@
   <div id="settings">
     <div class="settings-contents">
       <h1 class="title">ユーザ設定</h1>
-      <SettingsInfo :change_island_name_price="change_island_name_price"> </SettingsInfo>
-      <SettingsTheme></SettingsTheme>
+      <SettingsInfo :change_island_name_price="change_island_name_price" />
+      <SettingsTheme />
     </div>
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue'
-import { Status } from '../../../store/Entity/Status'
-import { useMainStore } from '../../../store/MainStore'
+<script setup lang="ts">
+import { Status } from '../../../store/Entity/Status.js'
+import { useMainStore } from '../../../store/MainStore.js'
 import SettingsInfo from './SettingsInfo.vue'
 import SettingsTheme from './SettingsTheme.vue'
 
-export default defineComponent({
-  components: { SettingsTheme, SettingsInfo },
-  setup(props) {
-    const store = useMainStore()
-    store.$patch({
-      island: {
-        id: props.island.id,
-        name: props.island.name,
-        owner_name: props.island.owner_name
-      },
-      status: props.island.status
-    })
-    return { store }
-  },
-  props: {
-    island: {
-      required: true,
-      type: Object as PropType<{
-        id: number
-        name: string
-        owner_name: string
-        status: Status
-      }>
-    },
-    change_island_name_price: {
-      required: true,
-      type: Number
-    }
+interface Props {
+  island: {
+    id: number
+    name: string
+    owner_name: string
+    status: Status
   }
+  change_island_name_price: number
+}
+const props = defineProps<Props>()
+
+const store = useMainStore()
+
+store.$patch((state) => {
+  state.island = {
+    id: props.island.id,
+    name: props.island.name,
+    owner_name: props.island.owner_name
+  }
+  state.status = props.island.status
 })
 </script>
 

--- a/app/resources/js/components/pages/Settings/SettingsTheme.vue
+++ b/app/resources/js/components/pages/Settings/SettingsTheme.vue
@@ -11,33 +11,33 @@
       <h3 class="samples-title">サンプル</h3>
       <div class="samples-wrapper">
         <div class="samples-grid">
-          <div class="sample-box bg-background text-on-background">background</div>
-          <div class="sample-box bg-surface text-on-surface">surface</div>
-          <div class="sample-box bg-primary text-on-primary">
-            <div class="sample-box">primary</div>
-            <div class="sample-box bg-primary-container text-on-primary-container">primary container</div>
+          <div class="bg-background text-on-background">background</div>
+          <div class="bg-surface text-on-surface">surface</div>
+          <div class="bg-primary text-on-primary">
+            <div>primary</div>
+            <div class="bg-primary-container text-on-primary-container">primary container</div>
           </div>
-          <div class="sample-box bg-secondary text-on-secondary">
-            <div class="sample-box">secondary</div>
-            <div class="sample-box bg-secondary-container text-on-secondary-container">secondary container</div>
+          <div class="bg-secondary text-on-secondary">
+            <div>secondary</div>
+            <div class="bg-secondary-container text-on-secondary-container">secondary container</div>
           </div>
-          <div class="sample-box bg-alert text-on-alert">
-            <div class="sample-box">alert</div>
-            <div class="sample-box bg-alert-container text-on-alert-container">alert container</div>
+          <div class="bg-alert text-on-alert">
+            <div>alert</div>
+            <div class="bg-alert-container text-on-alert-container">alert container</div>
           </div>
-          <div class="sample-box bg-error text-on-error">
-            <div class="sample-box">error</div>
-            <div class="sample-box bg-error-container text-on-error-container">error container</div>
+          <div class="bg-error text-on-error">
+            <div>error</div>
+            <div class="bg-error-container text-on-error-container">error container</div>
           </div>
-          <div class="sample-box bg-surface-variant text-on-surface-variant">surface-variant</div>
-          <div class="sample-box border-2">outline</div>
-          <div class="sample-box font-bold text-on-link">Link Text Color</div>
-          <div class="sample-box font-bold">
-            <div class="sample-box">
+          <div class="bg-surface-variant text-on-surface-variant">surface-variant</div>
+          <div class="border-2">outline</div>
+          <div class="font-bold text-on-link">Link Text Color</div>
+          <div class="font-bold">
+            <div>
               <span class="mr-3">PLUS</span>
               <span class="border-b-2 border-b-plus text-on-plus">+ 100 pts</span>
             </div>
-            <div class="sample-box">
+            <div>
               <span class="mr-3">MINUS</span>
               <span class="border-b-2 border-b-minus text-on-minus">- 100 pts</span>
             </div>
@@ -48,29 +48,19 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue'
-import themes from '../../../ThemeList.json'
-import { Theme } from '../../../store/Entity/Theme'
-import { useMainStore } from '../../../store/MainStore'
+<script setup lang="ts">
+import { ref } from 'vue'
+import themeListJson from '../../../ThemeList.json'
+import { Theme } from '../../../store/Entity/Theme.js'
+import { useMainStore } from '../../../store/MainStore.js'
 
-export default defineComponent({
-  data() {
-    return {
-      themes: themes as Theme[]
-    }
-  },
-  setup() {
-    const store = useMainStore()
-    return { store }
-  },
-  methods: {
-    onClickTheme(theme: Theme) {
-      if (this.store.theme.name === theme.name) return
-      this.store.changeTheme(theme)
-    }
-  }
-})
+const themes = ref<Theme[]>(themeListJson as Theme[])
+const store = useMainStore()
+
+const onClickTheme = (theme: Theme) => {
+  if (store.theme.name === theme.name) return
+  store.changeTheme(theme)
+}
 </script>
 
 <style scoped lang="scss">
@@ -116,7 +106,7 @@ export default defineComponent({
         @apply md:grid-cols-2;
       }
 
-      .sample-box {
+      div {
         @apply flex min-h-[4rem] w-full flex-wrap items-center justify-center rounded-md p-3;
       }
     }

--- a/app/resources/js/debug.ts
+++ b/app/resources/js/debug.ts
@@ -1,6 +1,6 @@
 import './bootstrap'
 import DebugTools from './components/layout/DebugTools.vue'
-import { app } from './bootstrap'
+import { app } from './bootstrap.js'
 
 console.debug('---development mode---')
 app.component('DebugTools', DebugTools)

--- a/app/resources/js/declarations/markdown-it-sanitizer.d.ts
+++ b/app/resources/js/declarations/markdown-it-sanitizer.d.ts
@@ -1,0 +1,5 @@
+declare module 'markdown-it-sanitizer' {
+  import { PluginSimple, PluginWithParams, PluginWithOptions } from 'markdown-it'
+  const sanitizer: PluginSimple | PluginWithParams | PluginWithOptions
+  export default sanitizer
+}

--- a/app/resources/views/components/header.blade.php
+++ b/app/resources/views/components/header.blade.php
@@ -12,7 +12,10 @@
     ></vue-header>
     @if(\App::environment('local') && \APP::hasDebugModeEnabled() && file_exists(public_path('hot')))
         <debug-tools
-            :debug-login-using-id="{{ config('app.hakoniwa.debug.login_using_id') }}"
+            @php($debug_login_id = config('app.hakoniwa.debug.login_using_id'))
+            @if($debug_login_id !== null)
+                :debug-login-using-id="{{ $debug_login_id }}"
+            @endif
         ></debug-tools>
     @endif
 </header>

--- a/app/resources/views/components/header.blade.php
+++ b/app/resources/views/components/header.blade.php
@@ -12,9 +12,8 @@
     ></vue-header>
     @if(\App::environment('local') && \APP::hasDebugModeEnabled() && file_exists(public_path('hot')))
         <debug-tools
-            @php($debug_login_id = config('app.hakoniwa.debug.login_using_id'))
-            @if($debug_login_id !== null)
-                :debug-login-using-id="{{ $debug_login_id }}"
+            @if(is_numeric(config('app.hakoniwa.debug.login_using_id')))
+                :debug-login-using-id="{{ config('app.hakoniwa.debug.login_using_id') }}"
             @endif
         ></debug-tools>
     @endif


### PR DESCRIPTION
## Overview

Settings, Releasesページ関連のComposition API化およびリファクタを行いました。

## Refactored Components

- SettingsPage.vue
  - SettingsTheme.vue
  - StatusInfo.vue
- ReleasesPage.vue
  - ReleasesMarkdown.vue

リファクタリングのために以下の軽微な修正を含んでいます。

- SettingsTheme.vue
  - CSSセレクタの修正
- SettingsPage.vue
  - Typescriptのstrict対応のため、`store.$patch`処理を `(state) => {}` で修正する方式に変更
- ReleasesMarkdown.vue
  - `@ts-ignore` が納得いかないので、自前で `markdown-it-sanitizer.d.ts` の型定義ファイルを作成
  - `js/declarations` 内にありますが、ディレクトリ構成が納得いかなかったら変更します

## Debug

その他、軽微なバグ修正を含みます。

### Vite 5.x系のための `import` 文修正

Vite 5.xへの更新により内部の Rollup が4系に更新されたのですが、その対応のために `CompilerOptions.moduleResolution` を `nodenext` に変更しました。

`node16` 以降の設定を使った場合、 `import` 文でインポートするファイルの拡張子を省略しないような決まりになっているようで、IDE上でエラーが発生するようです。今回記述したコードについては一通り修正してあります。

今の所Javascriptへのビルドでこのエラーがあっても問題はないようですが、IDEのアラートがごちゃごちゃになるので早めに解決しておきたいです。

### DEBUG_LOGIN_USING_ID 未定義時の動作

development環境の時、.envにDEBUG_LOGIN_USING_IDが定義されていないとconfigの取得値がnullになってしまうようです。
結果としてpropsに空文字列が渡されてしまい、Vueがブラウザのconsole上でWarningを吐いてしまいます。

Blede側でnullチェックを行い、値が存在しない場合はpropsを渡さないように修正しました。