### PR TITLE
indexページのCSS&デザイン修正

### DIFF
--- a/app/resources/views/pages/index.blade.php
+++ b/app/resources/views/pages/index.blade.php
@@ -3,57 +3,14 @@
 @section('contents')
     <div id="app">
         @include('components.header')
-        <div id="index">
-            <h1 class="title">やまにてぃ</h1>
-            <hr/>
-
-            <turn-viewer
-                :turn="@js($turn->turn)"
-                :day="@js($turn->next_turn_scheduled_at->format('Y-m-d'))"
-                :time="@js($turn->next_turn_scheduled_at->format('H:i'))"
-            ></turn-viewer>
-
-            <h2 class="subtitle">注意事項</h2>
-            <hr/>
-            <p class="box-secondary">現在開発中のため、多くの機能が未実装です。</p>
-            <p class="box-alert">テスト中にデータが消える可能性が高いため、何があっても許せる方のみ登録してください。</p>
-
-            <h2 class="subtitle">遊び方</h2>
-            <hr/>
-            <p>
-                TAITOの島育成ゲームソーシャルネットワークサービス「しまにてぃ」の要素を取り入れた平和系箱庭です。更新は約{{config('app.hakoniwa.turn_update_minutes')}}
-                分毎です。 </p>
-            <p>フルスクラッチで実装しているため、既存の箱庭と仕様が違う点はご容赦ください。連絡いただければ検討します。 </p>
-            <p>
-                ログインは（今のところ）Google連携のみ利用できます。メールアドレスとユーザー名をサーバーで保持するので、気になる人は捨て垢の利用を推奨します（パスワードはこちらでは保持しません）。 </p>
-            <p>不具合・不明点はツイッターからご連絡ください。 </p>
-            <p class="box-error">重複登録は禁止です。1人1島でお願いします。</p>
-
-            <h2 class="subtitle mt-20">現在のランキング</h2>
-            <hr/>
-
-            @if(count($islands) === 0)
-                <p>島が登録されていません</p>
-            @endif
-
-            @foreach($islands as $index => $island)
-                <ranking-viewer
-                    class="index-ranking-viewer rounded-md"
-                    :index="@js($index+1)"
-                    :island="@js($island)"
-                ></ranking-viewer>
-            @endforeach
-
-
-            @if(count($logs) > 0)
-                <log-viewer
-                    class="index-ranking-viewer"
-                    :title="'最近の出来事'"
-                    :unparsed-logs="@js($logs)"
-                ></log-viewer>
-            @endif
-
-        </div>
+        <index-page
+            turn="{{$turn->turn}}"
+            day="{{$turn->next_turn_scheduled_at->format('Y-m-d')}}"
+            time="{{$turn->next_turn_scheduled_at->format('H:i')}}"
+            update-interval="{{config('app.hakoniwa.turn_update_minutes')}}"
+            :ranking-islands="@js($islands)"
+            :logs="@js($logs)"
+        ></index-page>
         @include('components.footer')
     </div>
 @endsection

--- a/frontend/src/css/app.scss
+++ b/frontend/src/css/app.scss
@@ -46,19 +46,6 @@
 }
 
 @layer components {
-  // components
-  .title {
-    @apply mb-2 mt-6 text-2xl font-black;
-  }
-
-  .subtitle {
-    @apply mb-2 mt-6 text-xl;
-  }
-
-  .link-text {
-    @apply text-on-link;
-  }
-
   // ----- InfoBox -----
   .box-secondary {
     @apply my-3 block rounded bg-secondary-container p-4 text-base font-bold drop-shadow-md;
@@ -121,18 +108,6 @@
 
 #app {
   @apply bg-background pb-0 text-on-background;
-}
-
-#index {
-  @apply mx-auto max-w-[1000px] px-3;
-
-  .index-ranking-viewer {
-    @apply rounded-md;
-
-    .subtitle {
-      @apply rounded-t-md;
-    }
-  }
 }
 
 #register {

--- a/frontend/src/css/app.scss
+++ b/frontend/src/css/app.scss
@@ -46,19 +46,6 @@
 }
 
 @layer components {
-  // ----- InfoBox -----
-  .box-secondary {
-    @apply my-3 block rounded bg-secondary-container p-4 text-base font-bold drop-shadow-md;
-  }
-
-  .box-alert {
-    @apply my-3 block rounded bg-alert-container p-4 text-base font-bold text-on-alert-container drop-shadow-md;
-  }
-
-  .box-error {
-    @apply my-3 block rounded bg-error p-4 text-base font-bold text-on-error drop-shadow-md;
-  }
-
   // ----- ボタン -----
   .button-primary {
     @apply inline-block rounded border px-4 py-2 drop-shadow-md;

--- a/frontend/src/js/bootstrap.ts
+++ b/frontend/src/js/bootstrap.ts
@@ -20,25 +20,21 @@ import Tres from '@tresjs/core'
 import IslandsPage from '$vue/pages/Islands/IslandsPage.vue'
 import PlansPage from '$vue/pages/Islands/Plans/PlansPage.vue'
 import VueHeader from '$vue/layout/VueHeader.vue'
-import TurnViewer from '$vue/pages/Index/TurnViewer.vue'
-import RankingViewer from '$vue/pages/Index/RankingViewer.vue'
-import LogViewer from '$vue/components/islands/common/LogViewer.vue'
 import SettingsPage from '$vue/pages/Settings/SettingsPage.vue'
 import ReleaseNotes from '$vue/pages/Releases/ReleasesPage.vue'
 import VueFooter from '$vue/layout/VueFooter.vue'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import ReleasesPage from '$vue/pages/Releases/ReleasesPage.vue'
+import IndexPage from '$vue/pages/Index/IndexPage.vue'
 
 export const app: App = createApp({
   components: {
+    IndexPage,
     IslandsPage,
     PlansPage,
     VueHeader,
     VueFooter,
-    TurnViewer,
     ReleaseNotes,
-    RankingViewer,
-    LogViewer,
     SettingsPage,
     ReleasesPage
   }

--- a/frontend/src/js/entity/Island.ts
+++ b/frontend/src/js/entity/Island.ts
@@ -1,4 +1,5 @@
 import { Terrain } from './Terrain.js'
+import {AchievementProp} from "$entity/Achievement.js";
 
 export interface Island {
   id: number
@@ -6,6 +7,25 @@ export interface Island {
   owner_name: string
   comment?: string
   terrains?: Terrain[]
+}
+
+export interface IslandWithStatuses {
+  id: number
+  name: string
+  owner_name: string
+  development_points: number
+  funds: number
+  foods: number
+  resources: number
+  population: number
+  funds_production_capacity: number
+  foods_production_capacity: number
+  resources_production_capacity: number
+  environment: string
+  area: number
+  abandoned_turn: number
+  comment: string
+  achievements: AchievementProp[]
 }
 
 export type IslandEnvironment = 'best' | 'good' | 'normal'

--- a/frontend/src/vue/components/ui/InfoBox.vue
+++ b/frontend/src/vue/components/ui/InfoBox.vue
@@ -1,0 +1,91 @@
+<template>
+  <div :class="['infobox', props.type]">
+    <FontAwesomeIcon class="info-icon" :icon="icon" />
+    <div class="info-contents">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { faCircleExclamation, faTriangleExclamation, faCircleXmark } from '@fortawesome/free-solid-svg-icons'
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { computed } from 'vue'
+
+library.add(faCircleExclamation, faTriangleExclamation, faCircleXmark)
+
+type InfoboxType = 'notify' | 'alert' | 'error'
+
+type Props = {
+  type: InfoboxType
+  faIcon?: string[]
+}
+const props = defineProps<Props>()
+
+const icon = computed<string[]>(() => {
+  if (props.faIcon == null) {
+    switch (props.type) {
+      case 'notify':
+        return ['fas', 'circle-exclamation']
+      case 'alert':
+        return ['fas', 'triangle-exclamation']
+      case 'error':
+        return ['fas', 'circle-xmark']
+    }
+  } else {
+    return props.faIcon
+  }
+})
+</script>
+
+<style scoped lang="scss">
+.infobox {
+  @apply my-3 flex gap-3 rounded p-4 text-base font-bold drop-shadow-md items-center justify-center;
+  @apply md:gap-6;
+
+  .info-icon {
+    @apply h-7 w-7;
+  }
+
+  .info-contents {
+    @apply w-full;
+  }
+
+  &.notify {
+    @apply bg-secondary-container;
+
+    .info-icon {
+      @apply text-secondary;
+    }
+
+    .info-contents {
+      @apply  text-on-secondary-container;
+    }
+  }
+
+  &.alert {
+    @apply bg-alert-container;
+
+    .info-icon {
+      @apply text-alert;
+    }
+
+    .info-contents {
+      @apply  text-on-alert-container;
+    }
+  }
+
+  &.error {
+    @apply bg-error-container;
+
+    .info-icon {
+      @apply text-error;
+    }
+
+    .info-contents {
+      @apply  text-on-error-container;
+    }
+  }
+}
+</style>

--- a/frontend/src/vue/pages/Index/IndexPage.vue
+++ b/frontend/src/vue/pages/Index/IndexPage.vue
@@ -1,0 +1,68 @@
+<template>
+  <div id="index">
+    <h1 class="title">やまにてぃ</h1>
+
+    <TurnViewer :turn="props.turn" :day="props.day" :time="props.time" />
+
+    <h2 class="subtitle">注意事項</h2>
+    <p class="box-secondary">現在開発中のため、多くの機能が未実装です。</p>
+    <p class="box-alert">テスト中にデータが消える可能性が高いため、何があっても許せる方のみ登録してください。</p>
+
+    <h2 class="subtitle">遊び方</h2>
+    <p>
+      TAITOの島育成ゲームソーシャルネットワークサービス「しまにてぃ」の要素を取り入れた平和系箱庭です。 更新は約
+      {{ props.updateInterval }} 分毎です。
+    </p>
+    <p>フルスクラッチで実装しているため、既存の箱庭と仕様が違う点はご容赦ください。連絡いただければ検討します。</p>
+    <p>
+      ログインは（今のところ）Google連携のみ利用できます。メールアドレスとユーザー名をサーバーで保持するので、気になる人は捨て垢の利用を推奨します（パスワードはこちらでは保持しません）。
+    </p>
+    <p>不具合・不明点はツイッターからご連絡ください。</p>
+    <p class="box-error">重複登録は禁止です。1人1島でお願いします。</p>
+
+    <h2 class="subtitle mt-20">現在のランキング</h2>
+    <template v-if="props.rankingIslands.length > 0">
+      <RankingViewer
+        v-for="(island, index) in props.rankingIslands"
+        :island="island"
+        :index="index + 1"
+        :key="island.id" />
+    </template>
+    <p v-else>島が登録されていません</p>
+
+    <LogViewer v-if="props.logs != null" title="最近の出来事" :unparsed-logs="props.logs" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import TurnViewer from '$vue/pages/Index/TurnViewer.vue'
+import RankingViewer from '$vue/pages/Index/RankingViewer.vue'
+import { IslandWithStatuses } from '$entity/Island.js'
+import LogViewer from '$vue/components/islands/common/LogViewer.vue'
+import { LogProps } from '$entity/Log.js'
+
+type Props = {
+  turn: string
+  day: string
+  time: string
+  updateInterval: string
+  rankingIslands: IslandWithStatuses[]
+  logs: LogProps[]
+}
+
+const props = defineProps<Props>()
+</script>
+
+<style scoped lang="scss">
+#index {
+  @apply mx-auto max-w-[1000px] px-3;
+
+  .title {
+    @apply mb-4 mt-6 border-b pb-1 text-2xl font-black;
+  }
+
+  .subtitle {
+    @apply mb-2 mt-6 border-b text-lg;
+  }
+}
+</style>

--- a/frontend/src/vue/pages/Index/IndexPage.vue
+++ b/frontend/src/vue/pages/Index/IndexPage.vue
@@ -5,8 +5,12 @@
     <TurnViewer :turn="props.turn" :day="props.day" :time="props.time" />
 
     <h2 class="subtitle">注意事項</h2>
-    <p class="box-secondary">現在開発中のため、多くの機能が未実装です。</p>
-    <p class="box-alert">テスト中にデータが消える可能性が高いため、何があっても許せる方のみ登録してください。</p>
+    <InfoBox type="notify">
+      現在開発中のため、多くの機能が未実装です。
+    </InfoBox>
+    <InfoBox type="alert">
+      テスト中にデータが消える可能性が高いため、何があっても許せる方のみ登録してください。
+    </InfoBox>
 
     <h2 class="subtitle">遊び方</h2>
     <p>
@@ -18,7 +22,9 @@
       ログインは（今のところ）Google連携のみ利用できます。メールアドレスとユーザー名をサーバーで保持するので、気になる人は捨て垢の利用を推奨します（パスワードはこちらでは保持しません）。
     </p>
     <p>不具合・不明点はツイッターからご連絡ください。</p>
-    <p class="box-error">重複登録は禁止です。1人1島でお願いします。</p>
+    <InfoBox type="error">
+      重複登録は禁止です。1人1島でお願いします。
+    </InfoBox>
 
     <h2 class="subtitle mt-20">現在のランキング</h2>
     <template v-if="props.rankingIslands.length > 0">
@@ -40,6 +46,7 @@ import RankingViewer from '$vue/pages/Index/RankingViewer.vue'
 import { IslandWithStatuses } from '$entity/Island.js'
 import LogViewer from '$vue/components/islands/common/LogViewer.vue'
 import { LogProps } from '$entity/Log.js'
+import InfoBox from "$vue/components/ui/InfoBox.vue";
 
 type Props = {
   turn: string

--- a/frontend/src/vue/pages/Index/RankingViewer.vue
+++ b/frontend/src/vue/pages/Index/RankingViewer.vue
@@ -65,31 +65,11 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
-import { AchievementProp } from '$entity/Achievement'
 import AchievementIcons from '$vue/components/ui/AchievementIcons.vue'
-
-interface IslandWithStatuses {
-  id: number
-  name: string
-  owner_name: string
-  development_points: number
-  funds: number
-  foods: number
-  resources: number
-  population: number
-  funds_production_capacity: number
-  foods_production_capacity: number
-  resources_production_capacity: number
-  environment: string
-  area: number
-  abandoned_turn: number
-  comment: string
-  achievements: AchievementProp[]
-}
+import { IslandWithStatuses } from '$entity/Island.js'
 
 interface Props {
   index: number
-  // TODO: ランキングのIslandデータ型は個別で定義しておいた方がよい？
   island: IslandWithStatuses
 }
 

--- a/frontend/src/vue/pages/Index/TurnViewer.vue
+++ b/frontend/src/vue/pages/Index/TurnViewer.vue
@@ -2,23 +2,25 @@
   <div class="grid grid-cols-2 gap-4">
     <div class="turn-box">
       <h2 class="turn-box-title">ターン</h2>
-      <p class="turn-box-text-big m-0 h-2/3">{{ $props.turn }}</p>
+      <p class="turn-box-text-big m-0 h-2/3">{{ props.turn }}</p>
     </div>
     <div class="turn-box">
       <h2 class="turn-box-title">次回更新予定</h2>
-      <p class="turn-box-text-big max-md:hidden">{{ $props.day + ' ' + $props.time }}</p>
-      <p class="turn-box-text-medium mb-0 md:hidden">{{ $props.day }}</p>
-      <p class="turn-box-text-medium -mt-1 md:hidden">{{ $props.time }}</p>
+      <p class="turn-box-text-big max-md:hidden">{{ props.day + ' ' + props.time }}</p>
+      <p class="turn-box-text-medium mb-0 md:hidden">{{ props.day }}</p>
+      <p class="turn-box-text-medium -mt-1 md:hidden">{{ props.time }}</p>
     </div>
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue'
+<script setup lang="ts">
+type Props = {
+  turn: string
+  day: string
+  time: string
+}
 
-export default defineComponent({
-  props: ['turn', 'day', 'time']
-})
+const props = defineProps<Props>()
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
## Overview

indexページのCSS周りやデザインの修正、bladeテンプレートからvueへの置き換えを行いました。

### index.blade.phpの内容をIndexPage.vueへ置き換え

`index.blade.php` の内容を新たに作成した `IndexPage.vue` に置き換えました。

このbladeの影響で一部CSSが `app.scss` に記載していたことにより、`scoped` になっておらず他のコンポーネントのデザインに悪影響を及ぼしていたため、Vueファイルに分割し閉じ込めるようにしました。

この修正によるデザインの変更はありません。

### Infoboxの実装

indexページで使っていた `.box-alert` や `.box-error` などについて、CSSの定義だけで拡張性に乏しい状態でした。そこで新たにInfoBoxコンポーネントを実装しました。

オマケとしてアイコン設定も出来るようになっています。FontAwesomeのクラスを指定するとアイコンを決められます。指定しない場合は `notify` `alert` `error`のボックス指定によって自動的にアイコンが割り当てられます。
独自アイコンを使用する場合は、 `library.add()` をお忘れなく…

![image](https://github.com/mjtakenon/hakoniwa/assets/130939038/e279f5fd-060f-44db-b7ae-deb4f4e474a9)