### PR TITLE
実績のアイコンホバー時に、他の島の情報を取ってきてしまう問題の修正

### DIFF
--- a/frontend/src/js/entity/Achievement.ts
+++ b/frontend/src/js/entity/Achievement.ts
@@ -41,9 +41,10 @@ import AchievementLists from '$js/store/AchievementList.json'
  */
 export const getAchievement = (data: AchievementProp): Achievement => {
   let index = 0
+
   for (const achieve of AchievementLists) {
     if (data.type === achieve.type) {
-      let result = achieve as Achievement
+      let result = structuredClone(achieve) as Achievement
       result.index = index
       result.hover_text = data.hover_text ?? undefined
       result.extra_text = data.extra_text ?? undefined

--- a/frontend/src/vue/components/ui/AchievementIcons.vue
+++ b/frontend/src/vue/components/ui/AchievementIcons.vue
@@ -67,16 +67,17 @@ const hoverWindow = ref({
 
 const BOTTOM_OFFSET = 40
 
-let achievements: Achievement[]
+const achievements = ref<Achievement[]>(null)
 if (props.achievement_data === undefined) {
-  achievements = filterDuplicatedAchievementType(getAchievementsList(props.achievement_props))
+  achievements.value = filterDuplicatedAchievementType(getAchievementsList(props.achievement_props))
 } else {
-  achievements = filterDuplicatedAchievementType(props.achievement_data)
+  achievements.value = filterDuplicatedAchievementType(props.achievement_data)
 }
-sortAchievements(achievements)
+
+sortAchievements(achievements.value)
 
 const cols = ref(props.max_cols)
-if (achievements.length < cols.value) cols.value = achievements.length
+if (achievements.value.length < cols.value) cols.value = achievements.value.length
 if (cols.value === 0) cols.value = 1
 
 // Computed
@@ -85,7 +86,7 @@ const gridColumns = computed(() => {
 })
 
 const hasAchievement = computed(() => {
-  return achievements !== null && achievements !== undefined && achievements.length > 0
+  return achievements !== null && achievements !== undefined && achievements.value.length > 0
 })
 
 const onHover = (event: MouseEvent, title: string, text: string) => {


### PR DESCRIPTION
## Overview

実績のアイコンホバー時に他の島の情報を取ってきてしまう問題を修正しました。

`Achievement.ts` 内の処理でAchievementListから取得したテンプレートを基に展開していたのですが、**人類は愚か**なのでそのまま参照を書き換えるとかいうとんでもないミスをしていました。 `structuredClone()` を使用することで解決済みです。

その他に `AchievementIcons.vue` の `achievements` を `ref` に変更しました。こちらは一応現状のコードでも問題ないのですが、将来的に実績周りの更新処理でリアクティブにならない問題を起こしそうなので、合わせて変更してあります。

fixed #169