### PR TITLE
tscによるチェックと修正

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
     "dev": "vite",
     "build": "vite build",
     "prettier-format": "prettier . --write",
-    "prettier-check": "prettier . --check"
+    "prettier-check": "prettier . --check",
+    "tsc-check": "tsc --noEmit"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.192",

--- a/frontend/src/js/bootstrap.ts
+++ b/frontend/src/js/bootstrap.ts
@@ -11,10 +11,9 @@ window._ = _
 import axios from 'axios'
 
 axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest'
-window.axios = axios
 
 import { App } from 'vue'
-import { createApp } from 'vue/dist/vue.esm-bundler'
+import { createApp } from 'vue/dist/vue.esm-bundler.js'
 import { createPinia } from 'pinia'
 import Tres from '@tresjs/core'
 import IslandsPage from '$vue/pages/Islands/IslandsPage.vue'

--- a/frontend/src/js/store/IslandEditorStore.ts
+++ b/frontend/src/js/store/IslandEditorStore.ts
@@ -96,7 +96,7 @@ export const useIslandEditorStore = defineStore('island-editor', () => {
     if (target.length < 1) throw new Error('存在しない島IDです')
     if (target.length > 1) throw new Error('targetIslandに島が重複しています')
     // 既にロード済みの場合
-    if (target[0].terrains !== undefined) {
+    if (target[0].terrain !== undefined) {
       isLoadingTerrain.value = false
       return
     }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "module": "esnext",
-    "moduleResolution": "nodenext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
 
     "strict": true,
     "noImplicitAny": false,
@@ -22,6 +22,7 @@
 
     // Path aliases
     "baseUrl": "./",
+    "skipLibCheck": true,
     "paths": {
       "$css/*": ["src/css/*"],
       "$js/*": ["src/js/*"],


### PR DESCRIPTION
## 概要

Store分割バグの問題があったため、一旦tscでチェックをかけました。
エラーになっていた箇所は修正済みです。ビルドも問題なく行えています。

## 修正内容

- チェック用コマンドを `package.json` に追加
- tsconfig.jsonの修正
  - `module` の設定が誤っていた問題を修正
  - tscがnode_modules内を含んでしまったため、 `skipLipCheck` オプションを追加
- `IslandEditorStore.ts` の変数名の誤りを修正
- `bootstrap.ts` の修正
  - 使用していない `window.axios` を削除
  - importのfromに `.js` が欠けていたため追加